### PR TITLE
chore(openai): Add support for HTTP proxy configuration.

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -46,6 +46,7 @@ var commitCmd = &cobra.Command{
 			viper.GetString("openai.api_key"),
 			viper.GetString("openai.model"),
 			viper.GetString("openai.org_id"),
+			viper.GetString("openai.proxy"),
 		)
 		if err != nil {
 			return err

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -10,16 +10,18 @@ import (
 	"github.com/spf13/viper"
 )
 
-var availableKeys = []string{"openai.api_key", "openai.model", "openai.org_id", "output.lang"}
+var availableKeys = []string{"openai.api_key", "openai.model", "openai.org_id", "openai.proxy", "output.lang"}
 
 func init() {
 	configCmd.PersistentFlags().StringP("api_key", "k", "", "openai api key")
 	configCmd.PersistentFlags().StringP("model", "m", "gpt-3.5-turbo", "openai model")
 	configCmd.PersistentFlags().StringP("lang", "l", "en", "summarizing language uses English by default")
 	configCmd.PersistentFlags().StringP("org_id", "o", "", "openai requesting organization")
+	configCmd.PersistentFlags().StringP("proxy", "", "", "http proxy")
 	_ = viper.BindPFlag("openai.org_id", configCmd.PersistentFlags().Lookup("org_id"))
 	_ = viper.BindPFlag("openai.api_key", configCmd.PersistentFlags().Lookup("api_key"))
 	_ = viper.BindPFlag("openai.model", configCmd.PersistentFlags().Lookup("model"))
+	_ = viper.BindPFlag("openai.proxy", configCmd.PersistentFlags().Lookup("proxy"))
 	_ = viper.BindPFlag("output.lang", configCmd.PersistentFlags().Lookup("lang"))
 }
 

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -3,6 +3,9 @@ package openai
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/url"
+	"time"
 
 	openai "github.com/sashabaranov/go-openai"
 )
@@ -94,7 +97,7 @@ func (c *Client) Completion(
 }
 
 // New for initialize OpenAI client interface.
-func New(token, model, orgID string) (*Client, error) {
+func New(token, model, orgID, proxyURL string) (*Client, error) {
 	instance := &Client{}
 	if token == "" {
 		return nil, errors.New("missing api key")
@@ -110,6 +113,18 @@ func New(token, model, orgID string) (*Client, error) {
 	if orgID != "" {
 		cfg.OrgID = orgID
 	}
+
+	if proxyURL != "" {
+		httpClient := &http.Client{
+			Timeout: time.Second * 10,
+		}
+		proxy, _ := url.Parse(proxyURL)
+		httpClient.Transport = &http.Transport{
+			Proxy: http.ProxyURL(proxy),
+		}
+		cfg.HTTPClient = httpClient
+	}
+
 	instance.client = openai.NewClientWithConfig(cfg)
 
 	return instance, nil


### PR DESCRIPTION
- Add `net/http` and `net/url` packages to `commit.go`
- Add `httpClient` and `proxy` variables to `commit.go`
- Add `proxy` flag to `config.go`
- Add `httpClient` argument to `New` function in `openai/openai.go`
- Add conditional assignment to `cfg.HTTPClient` in `New` function of `openai/openai.go`

fix https://github.com/appleboy/CodeGPT/issues/1