### PR TITLE
feat: allow specifying numbers of lines of diff context

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -10,14 +10,16 @@ import (
 	"github.com/spf13/viper"
 )
 
-var availableKeys = []string{"openai.api_key", "openai.model", "openai.org_id", "openai.proxy", "output.lang"}
+var availableKeys = []string{"git.diff.context", "openai.api_key", "openai.model", "openai.org_id", "openai.proxy", "output.lang"}
 
 func init() {
 	configCmd.PersistentFlags().StringP("api_key", "k", "", "openai api key")
+	configCmd.PersistentFlags().StringP("diff_context", "U", "3", "generate diffs with <n> lines of context")
 	configCmd.PersistentFlags().StringP("model", "m", "gpt-3.5-turbo", "openai model")
 	configCmd.PersistentFlags().StringP("lang", "l", "en", "summarizing language uses English by default")
 	configCmd.PersistentFlags().StringP("org_id", "o", "", "openai requesting organization")
 	configCmd.PersistentFlags().StringP("proxy", "", "", "http proxy")
+	_ = viper.BindPFlag("git.diff.context", configCmd.PersistentFlags().Lookup("diff_context"))
 	_ = viper.BindPFlag("openai.org_id", configCmd.PersistentFlags().Lookup("org_id"))
 	_ = viper.BindPFlag("openai.api_key", configCmd.PersistentFlags().Lookup("api_key"))
 	_ = viper.BindPFlag("openai.model", configCmd.PersistentFlags().Lookup("model"))

--- a/git/git.go
+++ b/git/git.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"log"
 	"os/exec"
+
+	"github.com/spf13/viper"
 )
 
 var excludeFromDiff = []string{
@@ -45,6 +47,7 @@ func diffFiles() *exec.Cmd {
 		"--ignore-all-space",
 		"--diff-algorithm=minimal",
 		"--function-context",
+		"--unified=" + viper.GetString("git.diff.context"),
 	}
 
 	args = append(args, excludeFiles()...)


### PR DESCRIPTION
Presumably, it may generate more precise result if more lines of diff context are provided. By default, it's `3` in git CLI.