### PR TITLE
feat: Add support for conventional commits and templates

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -99,6 +99,25 @@ var commitCmd = &cobra.Command{
 			return err
 		}
 
+		// support conventional commits
+		out, err = util.GetTemplate(
+			prompt.ConventionalCommitTemplate,
+			util.Data{
+				"summary_points": summarizeDiff,
+			},
+		)
+		if err != nil {
+			return err
+		}
+		conventionalCommitPrefix, err := client.Completion(cmd.Context(), out)
+		if err != nil {
+			return err
+		}
+
+		if conventionalCommitPrefix != "" {
+			summarizeTitle = conventionalCommitPrefix + ": " + summarizeTitle
+		}
+
 		if prompt.GetLanguage(viper.GetString("output.lang")) != prompt.DefaultLanguage {
 			out, err = util.GetTemplate(
 				prompt.TranslationTemplate,

--- a/git/git.go
+++ b/git/git.go
@@ -14,9 +14,7 @@ var excludeFromDiff = []string{
 	"go.sum",
 }
 
-type Command struct {
-	ignoreLists []string
-}
+type Command struct{}
 
 func (c *Command) excludeFiles() []string {
 	newFileLists := []string{}

--- a/prompt/prompt.go
+++ b/prompt/prompt.go
@@ -11,9 +11,10 @@ import (
 var files embed.FS
 
 const (
-	SummarizeFileDiffTemplate = "summarize_file_diff.tmpl"
-	SummarizeTitleTemplate    = "summarize_title.tmpl"
-	TranslationTemplate       = "translation.tmpl"
+	SummarizeFileDiffTemplate  = "summarize_file_diff.tmpl"
+	SummarizeTitleTemplate     = "summarize_title.tmpl"
+	ConventionalCommitTemplate = "conventional_commit.tmpl"
+	TranslationTemplate        = "translation.tmpl"
 )
 
 func init() {

--- a/prompt/templates/conventional_commit.tmpl
+++ b/prompt/templates/conventional_commit.tmpl
@@ -1,0 +1,25 @@
+You are an expert programmer, and you are trying to summarize a code change.
+You went over every file that was changed in it.
+For some of these files changes where too big and were omitted in the files diff summary.
+Determine the best label for the commit.
+
+Here are the labels you can choose from:
+
+- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
+- chore: Updating libraries, copyrights or other repo setting, includes updating dependencies.
+- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, GitHub Actions)
+- docs: Non-code changes, such as fixing typos or adding new documentation
+- feat: a commit of the type feat introduces a new feature to the codebase
+- fix: A commit of the type fix patches a bug in your codebase
+- perf: A code change that improves performance
+- refactor: A code change that neither fixes a bug nor adds a feature
+- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+- test: Adding missing tests or correcting existing tests
+
+
+THE FILE SUMMARIES:
+###
+{{ .summary_points }}
+###
+
+The label best describing this change:


### PR DESCRIPTION
- Add support for conventional commits
- Add a new template for conventional commits
- Update the `prompt.go` file to include the new template
- Remove the `ignoreLists` field from the `Command` struct in `git.go`

fix #9 