### PR TITLE
chore: Add option to disable automatic commits and skip verification.

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -18,10 +18,14 @@ import (
 var (
 	commitLang  string
 	commitModel string
+
+	// disbale auot commit in Hook mode
+	disableAutoCommit bool
 )
 
 func init() {
 	commitCmd.PersistentFlags().StringP("file", "f", ".git/COMMIT_EDITMSG", "commit message file")
+	commitCmd.PersistentFlags().BoolVar(&disableAutoCommit, "disbaleCommit", false, "disable auto commit message")
 	commitCmd.PersistentFlags().StringVar(&commitModel, "model", "gpt-3.5-turbo", "select openai model")
 	commitCmd.PersistentFlags().StringVar(&commitLang, "lang", "en", "summarizing language uses English by default")
 	_ = viper.BindPFlag("output.file", commitCmd.PersistentFlags().Lookup("file"))
@@ -152,6 +156,10 @@ var commitCmd = &cobra.Command{
 		err = os.WriteFile(viper.GetString("output.file"), []byte(message), 0o644)
 		if err != nil {
 			return err
+		}
+
+		if disableAutoCommit {
+			return nil
 		}
 
 		// git commit automatically

--- a/git/git.go
+++ b/git/git.go
@@ -78,6 +78,7 @@ func (c *Command) hookPath() *exec.Cmd {
 func (c *Command) commit(val string) *exec.Cmd {
 	args := []string{
 		"commit",
+		"--no-verify",
 		"--file",
 		val,
 	}

--- a/git/templates/prepare-commit-msg
+++ b/git/templates/prepare-commit-msg
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-codegpt commit --file $1
+codegpt commit --file $1 --disbaleCommit


### PR DESCRIPTION
- Add a `disableAutoCommit` flag to the `commit` command
- Add the `--no-verify` flag to the `commit` command
- Modify the `prepare-commit-msg` file to use the `--disbaleCommit` flag when invoking the `codegpt commit` command

fix #12 