### PR TITLE
style: improve consistency and clarity of commit messages

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -103,6 +103,9 @@ var commitCmd = &cobra.Command{
 			return err
 		}
 
+		// lowercase the first character of first word of the commit message and remove last period
+		summarizeTitle = strings.TrimRight(strings.ToLower(string(summarizeTitle[0]))+summarizeTitle[1:], ".")
+
 		// support conventional commits
 		out, err = util.GetTemplate(
 			prompt.ConventionalCommitTemplate,

--- a/git/git.go
+++ b/git/git.go
@@ -17,6 +17,7 @@ var excludeFromDiff = []string{
 	// yarn.lock, Cargo.lock, Gemfile.lock, Pipfile.lock, etc.
 	"*.lock",
 	"go.sum",
+	"go.mod",
 }
 
 type Command struct{}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/appleboy/CodeGPT
 go 1.20
 
 require (
-	github.com/appleboy/com v0.1.6
+	github.com/appleboy/com v0.1.7
 	github.com/fatih/color v1.14.1
 	github.com/sashabaranov/go-openai v1.4.1
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/appleboy/com v0.1.6 h1:vP9ryTIbSFaXSrZcFTU7RRcgPbrpGJ0Oy5wpgEkQ2m8=
-github.com/appleboy/com v0.1.6/go.mod h1:jnufjIC3opMlReyPPPye+8JqNvUzLm25o7h6SOy8nv0=
+github.com/appleboy/com v0.1.7 h1:4lYTFNoMAAXGGIC8lDxVg/NY+1aXbYqfAWN05cZhd0M=
+github.com/appleboy/com v0.1.7/go.mod h1:JUK+oH0SXCLRH57pDMJx6VWVsm8CPdajalmRSWwamBE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=


### PR DESCRIPTION
- Add `go.mod` to the excluded files when diffing
- Lowercase the first character of the first word of the commit message and remove the last period

fix #17 