### PR TITLE
feat: add option to configure number of context lines in diffs

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -18,11 +18,14 @@ func init() {
 	configCmd.PersistentFlags().StringP("lang", "l", "en", "summarizing language uses English by default")
 	configCmd.PersistentFlags().StringP("org_id", "o", "", "openai requesting organization")
 	configCmd.PersistentFlags().StringP("proxy", "", "", "http proxy")
+	configCmd.PersistentFlags().IntP("diff_unified", "", 3, "generate diffs with <n> lines of context, default is 3")
+
 	_ = viper.BindPFlag("openai.org_id", configCmd.PersistentFlags().Lookup("org_id"))
 	_ = viper.BindPFlag("openai.api_key", configCmd.PersistentFlags().Lookup("api_key"))
 	_ = viper.BindPFlag("openai.model", configCmd.PersistentFlags().Lookup("model"))
 	_ = viper.BindPFlag("openai.proxy", configCmd.PersistentFlags().Lookup("proxy"))
 	_ = viper.BindPFlag("output.lang", configCmd.PersistentFlags().Lookup("lang"))
+	_ = viper.BindPFlag("git.diff_unified", configCmd.PersistentFlags().Lookup("diff_unified"))
 }
 
 var configCmd = &cobra.Command{

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,6 @@
-module.exports = {extends: ['@commitlint/config-conventional']}
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-max-line-length': [0, 'always', 'Infinity'],
+  },
+};

--- a/git/options.go
+++ b/git/options.go
@@ -1,0 +1,30 @@
+package git
+
+// Option is an interface that specifies instrumentation configuration options.
+type Option interface {
+	apply(*config)
+}
+
+// optionFunc is a type of function that can be used to implement the Option interface.
+// It takes a pointer to a config struct and modifies it.
+type optionFunc func(*config)
+
+// Ensure that optionFunc satisfies the Option interface.
+var _ Option = (*optionFunc)(nil)
+
+// The apply method of optionFunc type is implemented here to modify the config struct based on the function passed.
+func (o optionFunc) apply(c *config) {
+	o(c)
+}
+
+// WithDiffUnified is a function that generate diffs with <n> lines of context instead of the usual three.
+func WithDiffUnified(val int) Option {
+	return optionFunc(func(c *config) {
+		c.diffUnified = val
+	})
+}
+
+// config is a struct that stores configuration options for the instrumentation.
+type config struct {
+	diffUnified int
+}


### PR DESCRIPTION
- Add a `diff_unified` option to generate diffs with a specific number of lines of context.
- Modify `git.New()` to accept options to configure the `diff_unified` value.
- Add a new file `git/options.go` that defines an `Option` interface and a `WithDiffUnified` function to set the `diff_unified` value.

fix #21 
fix #6