### PR TITLE
docs: improve installation instructions for codegpt on MacOS via Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ A CLI written in [Go](https://go.dev) language that writes git commit messages f
 
 ## Installation
 
+Currently, the only supported method of installation on MacOS is [Homebrew](http://brew.sh/). To install `codegpt` via brew:
+
+```sh
+brew tap appleboy/tap
+brew install codegpt
+```
+
 The pre-compiled binaries can be downloaded from [release page](https://github.com/appleboy/CodeGPT/releases).
 
 On linux AMD64


### PR DESCRIPTION
- Add instructions for installing `codegpt` via Homebrew on MacOS
- Remove irrelevant context lines

fix https://github.com/appleboy/CodeGPT/issues/8