### PR TITLE
refactor: replace hyphens and dots in environment variable keys

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/appleboy/com/file"
 	"github.com/spf13/cobra"
@@ -20,7 +21,8 @@ var rootCmd = &cobra.Command{
 
 // Used for flags.
 var (
-	cfgFile string
+	cfgFile  string
+	replacer = strings.NewReplacer("-", "_", ".", "_")
 )
 
 func init() {
@@ -66,6 +68,7 @@ func initConfig() {
 		}
 	}
 
+	viper.SetEnvKeyReplacer(replacer)
 	viper.AutomaticEnv()
 
 	if err := viper.ReadInConfig(); err != nil {


### PR DESCRIPTION
- Added import for the "strings" package
- Defined a replacer for "-" and "." with "_" in variable "replacer"
- Added a call to "SetEnvKeyReplacer" for the "viper" object in the "initConfig" function.

fix https://github.com/appleboy/CodeGPT/issues/16