### PR TITLE
feat: add signoff flag to git commit command

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -25,6 +25,7 @@ var (
 	excludeList []string
 	httpsProxy  string
 	socksProxy  string
+	signoff     bool
 )
 
 func init() {
@@ -36,6 +37,7 @@ func init() {
 	commitCmd.PersistentFlags().StringSliceVar(&excludeList, "exclude_list", []string{}, "exclude file from git diff command")
 	commitCmd.PersistentFlags().StringVar(&httpsProxy, "proxy", "", "http proxy")
 	commitCmd.PersistentFlags().StringVar(&socksProxy, "socks", "", "socks proxy")
+	commitCmd.PersistentFlags().BoolVarP(&signoff, "signoff", "s", false, "add Signed-off-by line at the end of the commit message")
 	_ = viper.BindPFlag("output.file", commitCmd.PersistentFlags().Lookup("file"))
 }
 
@@ -216,7 +218,9 @@ var commitCmd = &cobra.Command{
 
 		// git commit automatically
 		color.Cyan("Git record changes to the repository")
-		output, err := g.Commit(message)
+		output, err := g.Commit(message, &git.CommitOption{
+			SignOff: signoff,
+		})
 		if err != nil {
 			return err
 		}

--- a/git/git.go
+++ b/git/git.go
@@ -81,11 +81,21 @@ func (c *Command) hookPath() *exec.Cmd {
 	)
 }
 
-func (c *Command) commit(val string) *exec.Cmd {
+type CommitOption struct {
+	SignOff bool
+}
+
+func (c *Command) commit(val string, opt *CommitOption) *exec.Cmd {
 	args := []string{
 		"commit",
 		"--no-verify",
 		fmt.Sprintf("--message=%s", val),
+	}
+
+	if opt != nil {
+		if opt.SignOff {
+			args = append(args, "--signoff")
+		}
 	}
 
 	return exec.Command(
@@ -94,8 +104,8 @@ func (c *Command) commit(val string) *exec.Cmd {
 	)
 }
 
-func (c *Command) Commit(val string) (string, error) {
-	output, err := c.commit(val).Output()
+func (c *Command) Commit(val string, opt *CommitOption) (string, error) {
+	output, err := c.commit(val, opt).Output()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Because sometimes we want to add something like "Signed-off-by: ZheNing Hu <adlternative@gmail.com>" 
to commit message end, so we can pass the "[-s|--signoff]" option to git to generate it.

Example:
```shell
$ codegpt commit -s
$ git log
commit 1c8bce4cae9141d2e588583e3e0bdd8b1f2efa75 (HEAD -> main)
Author: ZheNing Hu <adlternative@gmail.com>
Date:   Tue Mar 14 13:42:50 2023 +0800

    feat: add signoff flag to git commit command

    - Add a `signoff` flag to `git commit`
    - Modify `git.Commit()` to accept a `CommitOption` struct
    - Modify `commitCmd` to add `signoff` flag as a persistent flag

    Signed-off-by: ZheNing Hu <adlternative@gmail.com>
```