### PR TITLE
chore: add --signoff flag to git commit command

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -85,6 +85,7 @@ func (c *Command) commit(val string) *exec.Cmd {
 	args := []string{
 		"commit",
 		"--no-verify",
+		"--signoff",
 		fmt.Sprintf("--message=%s", val),
 	}
 


### PR DESCRIPTION
- Add the "--signoff" flag to the git commit command in line 87 of git.go.

fix #29 