### PR TITLE
feat: add template options to commit command

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -10,7 +10,18 @@ import (
 	"github.com/spf13/viper"
 )
 
-var availableKeys = []string{"openai.socks", "openai.api_key", "openai.model", "openai.org_id", "openai.proxy", "output.lang"}
+var availableKeys = []string{
+	"git.diff_unified",
+	"git.exclude_list",
+	"git.template_file",
+	"git.template_string",
+	"openai.socks",
+	"openai.api_key",
+	"openai.model",
+	"openai.org_id",
+	"openai.proxy",
+	"output.lang",
+}
 
 func init() {
 	configCmd.PersistentFlags().StringP("api_key", "k", "", "openai api key")
@@ -19,6 +30,8 @@ func init() {
 	configCmd.PersistentFlags().StringP("org_id", "o", "", "openai requesting organization")
 	configCmd.PersistentFlags().StringP("proxy", "", "", "http proxy")
 	configCmd.PersistentFlags().StringP("socks", "", "", "socks proxy")
+	configCmd.PersistentFlags().StringP("template_file", "", "", "git commit message file")
+	configCmd.PersistentFlags().StringP("template_string", "", "", "git commit message string")
 	configCmd.PersistentFlags().IntP("diff_unified", "", 3, "generate diffs with <n> lines of context, default is 3")
 	configCmd.PersistentFlags().StringSliceP("exclude_list", "", []string{}, "exclude file from `git diff` command")
 
@@ -30,6 +43,8 @@ func init() {
 	_ = viper.BindPFlag("output.lang", configCmd.PersistentFlags().Lookup("lang"))
 	_ = viper.BindPFlag("git.diff_unified", configCmd.PersistentFlags().Lookup("diff_unified"))
 	_ = viper.BindPFlag("git.exclude_list", configCmd.PersistentFlags().Lookup("exclude_list"))
+	_ = viper.BindPFlag("git.template_file", configCmd.PersistentFlags().Lookup("template_file"))
+	_ = viper.BindPFlag("git.template_string", configCmd.PersistentFlags().Lookup("template_string"))
 }
 
 var configCmd = &cobra.Command{

--- a/util/template.go
+++ b/util/template.go
@@ -16,6 +16,21 @@ var (
 	templatesDir = "templates"
 )
 
+func NewTemplateByString(format string, data map[string]interface{}) (string, error) {
+	t, err := template.New("message").Parse(format)
+	if err != nil {
+		return "", err
+	}
+
+	var tpl bytes.Buffer
+
+	if err := t.Execute(&tpl, data); err != nil {
+		return "", err
+	}
+
+	return tpl.String(), nil
+}
+
 func processTemplate(name string, data map[string]interface{}) (*bytes.Buffer, error) {
 	t, ok := templates[name]
 	if !ok {


### PR DESCRIPTION
- Add `template_file` and `template_string` flags to `commit` command
- Implement `NewTemplateByString` function for creating templates from string input

fix #31 