### PR TITLE
docs: correct flag name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,10 @@ We are trying to translate a git commit message to Traditional Chinese language
 Write the commit message to .git/COMMIT_EDITMSG file
 ```
 
-You can replace the tip of the current branch by creating a new commit. just use `--anmed` flag
+You can replace the tip of the current branch by creating a new commit. just use `--amend` flag
 
 ```sh
-codegpt commit --anmed
+codegpt commit --amend
 ```
 
 ## Change commit message template


### PR DESCRIPTION
- Fix a typo in the README.md file message
- Correct the flag name from `--anmed` to `--amend`