### PR TITLE
feat: set configurable timeout for openai client

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ This will create a `.codegpt.yaml` file in your home directory ($HOME/.config/co
 * **openai.lang**: default language is `en` and available languages `zh-tw`, `zh-tw`, `ja`.
 * **openai.proxy**: http/https client proxy.
 * **openai.socks**: socks client proxy.
+* **openai.timeout**: default http timeout is 10 seconds
 * **git.diff_unified**: generate diffs with `<n>` lines of context, default is `3`.
 * **git.exclue_list**: exclude file from `git diff` command.
 

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -112,6 +112,7 @@ var commitCmd = &cobra.Command{
 			openai.WithOrgID(viper.GetString("openai.org_id")),
 			openai.WithProxyURL(viper.GetString("openai.proxy")),
 			openai.WithSocksURL(viper.GetString("openai.socks")),
+			openai.WithTimeout(viper.GetDuration("openai.timeout")),
 		)
 		if err != nil {
 			return err

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -20,6 +20,7 @@ var availableKeys = []string{
 	"openai.model",
 	"openai.org_id",
 	"openai.proxy",
+	"openai.timeout",
 	"output.lang",
 }
 
@@ -40,6 +41,7 @@ func init() {
 	_ = viper.BindPFlag("openai.model", configCmd.PersistentFlags().Lookup("model"))
 	_ = viper.BindPFlag("openai.proxy", configCmd.PersistentFlags().Lookup("proxy"))
 	_ = viper.BindPFlag("openai.socks", configCmd.PersistentFlags().Lookup("socks"))
+	_ = viper.BindPFlag("openai.timeout", configCmd.PersistentFlags().Lookup("timeout"))
 	_ = viper.BindPFlag("output.lang", configCmd.PersistentFlags().Lookup("lang"))
 	_ = viper.BindPFlag("git.diff_unified", configCmd.PersistentFlags().Lookup("diff_unified"))
 	_ = viper.BindPFlag("git.exclude_list", configCmd.PersistentFlags().Lookup("exclude_list"))

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -154,7 +154,7 @@ func New(opts ...Option) (*Client, error) {
 	}
 
 	httpClient := &http.Client{
-		Timeout: time.Second * 10,
+		Timeout: cfg.timeout * time.Second,
 	}
 	if cfg.proxyURL != "" {
 		proxy, _ := url.Parse(cfg.proxyURL)

--- a/openai/options.go
+++ b/openai/options.go
@@ -1,5 +1,7 @@
 package openai
 
+import "time"
+
 // Option is an interface that specifies instrumentation configuration options.
 type Option interface {
 	apply(*config)
@@ -52,6 +54,17 @@ func WithSocksURL(val string) Option {
 	})
 }
 
+// WithTimeout is a function that returns an Option, which sets the timeout field of the config struct.
+func WithTimeout(val time.Duration) Option {
+	return optionFunc(func(c *config) {
+		if val < 1 {
+			c.timeout = 10
+			return
+		}
+		c.timeout = val
+	})
+}
+
 // config is a struct that stores configuration options for the instrumentation.
 type config struct {
 	token    string
@@ -59,4 +72,5 @@ type config struct {
 	model    string
 	proxyURL string
 	socksURL string
+	timeout  time.Duration
 }


### PR DESCRIPTION
- Add a `timeout` option to the `openai` client
- Bind the `timeout` flag to the `openai.timeout` configuration value
- Use the `timeout` value from the configuration in the `openai` client
- Create a new `WithTimeout` function that sets the `timeout` field of the `config` struct