### PR TITLE
feat: add code review command to CLI

### DIFF
--- a/cmd/review.go
+++ b/cmd/review.go
@@ -8,6 +8,7 @@ import (
 	"github.com/appleboy/CodeGPT/openai"
 	"github.com/appleboy/CodeGPT/prompt"
 	"github.com/appleboy/CodeGPT/util"
+
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/appleboy/CodeGPT/git"
+	"github.com/appleboy/CodeGPT/openai"
+	"github.com/appleboy/CodeGPT/prompt"
+	"github.com/appleboy/CodeGPT/util"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func init() {
+	reviewCmd.Flags().IntVar(&diffUnified, "diff_unified", 3, "generate diffs with <n> lines of context, default is 3")
+	reviewCmd.Flags().StringVar(&commitModel, "model", "gpt-3.5-turbo", "select openai model")
+	reviewCmd.Flags().StringVar(&commitLang, "lang", "en", "summarizing language uses English by default")
+	reviewCmd.Flags().StringSliceVar(&excludeList, "exclude_list", []string{}, "exclude file from git diff command")
+	reviewCmd.Flags().BoolVar(&commitAmend, "amend", false, "replace the tip of the current branch by creating a new commit.")
+}
+
+var reviewCmd = &cobra.Command{
+	Use:   "review",
+	Short: "Auto review code changes",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := check(); err != nil {
+			return err
+		}
+
+		g := git.New(
+			git.WithDiffUnified(viper.GetInt("git.diff_unified")),
+			git.WithExcludeList(viper.GetStringSlice("git.exclude_list")),
+			git.WithEnableAmend(commitAmend),
+		)
+		diff, err := g.DiffFiles()
+		if err != nil {
+			return err
+		}
+
+		color.Green("Code review your changes using " + viper.GetString("openai.model") + " model")
+		client, err := openai.New(
+			openai.WithToken(viper.GetString("openai.api_key")),
+			openai.WithModel(viper.GetString("openai.model")),
+			openai.WithOrgID(viper.GetString("openai.org_id")),
+			openai.WithProxyURL(viper.GetString("openai.proxy")),
+			openai.WithSocksURL(viper.GetString("openai.socks")),
+			openai.WithBaseURL(viper.GetString("openai.base_url")),
+			openai.WithTimeout(viper.GetDuration("openai.timeout")),
+		)
+		if err != nil {
+			return err
+		}
+
+		out, err := util.GetTemplateByString(
+			prompt.CodeReviewTemplate,
+			util.Data{
+				"file_diffs": diff,
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		// Get summarize comment from diff datas
+		color.Cyan("We are trying to review code changes")
+		resp, err := client.Completion(cmd.Context(), out)
+		if err != nil {
+			return err
+		}
+		summarizeMessage := resp.Content
+		color.Magenta("PromptTokens: " + strconv.Itoa(resp.Usage.PromptTokens) +
+			", CompletionTokens: " + strconv.Itoa(resp.Usage.CompletionTokens) +
+			", TotalTokens: " + strconv.Itoa(resp.Usage.TotalTokens),
+		)
+
+		// Output commit summary data from AI
+		color.Yellow("================Review Summary====================")
+		color.Yellow("\n" + strings.TrimSpace(summarizeMessage) + "\n\n")
+		color.Yellow("==================================================")
+
+		return nil
+	},
+}

--- a/prompt/prompt.go
+++ b/prompt/prompt.go
@@ -11,6 +11,7 @@ import (
 var files embed.FS
 
 const (
+	CodeReviewTemplate         = "code_review_file_diff.tmpl"
 	SummarizeFileDiffTemplate  = "summarize_file_diff.tmpl"
 	SummarizeTitleTemplate     = "summarize_title.tmpl"
 	ConventionalCommitTemplate = "conventional_commit.tmpl"

--- a/prompt/templates/code_review_file_diff.tmpl
+++ b/prompt/templates/code_review_file_diff.tmpl
@@ -1,0 +1,5 @@
+Bellow is the code patch, please help me do a brief code review if any bug risk, security vulnerabilities and improvement suggestion are welcome
+
+THE Code Patch TO BE Reviewed:
+
+{{ .file_diffs }}


### PR DESCRIPTION
- Add a new file `cmd/review.go`
- Add package imports for `github.com/appleboy/CodeGPT/git`, `github.com/appleboy/CodeGPT/openai`, `github.com/appleboy/CodeGPT/prompt`, `github.com/appleboy/CodeGPT/util`, `github.com/fatih/color`, `github.com/spf13/cobra`, and `github.com/spf13/viper`
- Add command line flags `diff_unified`, `model`, `lang`, `exclude_list`, and `amend` to `reviewCmd`
- Move initialization of command line flags to `init()` function
- Set up a `git` object with options, and call `g.DiffFiles()` to get the file diff data
- Set up an `openai` client with options, and call `client.Completion()` with the file diff data to get the AI-generated code review summary
- Add a new file `prompt/prompt.go

fix #45 