### PR TITLE
feat: update Git command struct with new functions

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,5 +2,6 @@ module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'body-max-line-length': [0, 'always', 'Infinity'],
+    'footer-max-line-length': [0, 'always', 'Infinity'],
   },
 };

--- a/git/git.go
+++ b/git/git.go
@@ -92,6 +92,18 @@ func (c *Command) hookPath() *exec.Cmd {
 	)
 }
 
+func (c *Command) topLevel() *exec.Cmd {
+	args := []string{
+		"rev-parse",
+		"--show-toplevel",
+	}
+
+	return exec.Command(
+		"git",
+		args...,
+	)
+}
+
 func (c *Command) commit(val string) *exec.Cmd {
 	args := []string{
 		"commit",
@@ -112,6 +124,17 @@ func (c *Command) commit(val string) *exec.Cmd {
 
 func (c *Command) Commit(val string) (string, error) {
 	output, err := c.commit(val).Output()
+	if err != nil {
+		return "", err
+	}
+
+	return string(output), nil
+}
+
+// TopLevel to show the (by default, absolute) path of the top-level directory of the working tree.
+// If there is no working tree, report an error.
+func (c *Command) TopLevel() (string, error) {
+	output, err := c.topLevel().Output()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
- Change the default value of the &#34;file&#34; flag to an empty string
- Add a &#34;topLevel&#34; function to the Git command struct, which returns the top-level directory of the working tree
- Add a &#34;Commit&#34; function to the Git command struct, which writes a commit with the given message and returns the commit hash

fix #49 