### PR TITLE
refactor: OpenAI provider initialization and testing

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -82,7 +82,7 @@ var commitCmd = &cobra.Command{
 			openai.WithTimeout(viper.GetDuration("openai.timeout")),
 			openai.WithMaxTokens(viper.GetInt("openai.max_tokens")),
 			openai.WithTemperature(float32(viper.GetFloat64("openai.temperature"))),
-			openai.WithServiceProvider(viper.GetString("openai.provider")),
+			openai.WithProvider(viper.GetString("openai.provider")),
 			openai.WithModelName(viper.GetString("openai.model_name")),
 		)
 		if err != nil {

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -56,7 +56,7 @@ var reviewCmd = &cobra.Command{
 			openai.WithTimeout(viper.GetDuration("openai.timeout")),
 			openai.WithMaxTokens(viper.GetInt("openai.max_tokens")),
 			openai.WithTemperature(float32(viper.GetFloat64("openai.temperature"))),
-			openai.WithServiceProvider(viper.GetString("openai.provider")),
+			openai.WithProvider(viper.GetString("openai.provider")),
 			openai.WithModelName(viper.GetString("openai.model_name")),
 		)
 		if err != nil {

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -140,12 +140,11 @@ func New(opts ...Option) (*Client, error) {
 		return nil, err
 	}
 
-	instance := &Client{}
-
-	v, _ := modelMaps[cfg.model]
-	instance.model = v
-	instance.maxTokens = cfg.maxTokens
-	instance.temperature = cfg.temperature
+	instance := &Client{
+		model:       modelMaps[cfg.model],
+		maxTokens:   cfg.maxTokens,
+		temperature: cfg.temperature,
+	}
 
 	c := openai.DefaultConfig(cfg.token)
 	if cfg.orgID != "" {

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -2,7 +2,6 @@ package openai
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -135,28 +134,15 @@ func (c *Client) Completion(
 // New is a function that takes a variadic slice of Option types and
 // returns a pointer to a Client and an error.
 func New(opts ...Option) (*Client, error) {
-	cfg := &config{
-		maxTokens:       defaultMaxTokens,
-		model:           defaultModel,
-		temperature:     defaultTemperature,
-		serviceProvider: defaultServiceProvider,
-	}
+	cfg := newConfig(opts...)
 
-	// Loop through each option
-	for _, o := range opts {
-		// Call the option giving the instantiated
-		o.apply(cfg)
+	if err := cfg.vaild(); err != nil {
+		return nil, err
 	}
 
 	instance := &Client{}
-	if cfg.token == "" {
-		return nil, errors.New("please set OPENAI_API_KEY environment variable")
-	}
 
-	v, ok := modelMaps[cfg.model]
-	if !ok {
-		return nil, errors.New("missing model")
-	}
+	v, _ := modelMaps[cfg.model]
 	instance.model = v
 	instance.maxTokens = cfg.maxTokens
 	instance.temperature = cfg.temperature
@@ -188,12 +174,10 @@ func New(opts ...Option) (*Client, error) {
 		}
 	}
 
-	if cfg.serviceProvider == AZURE {
-		if cfg.modelName == "" {
-			return nil, errors.New("missing Azure deployments model name")
-		}
-		config := openai.DefaultAzureConfig(cfg.token, cfg.baseURL, cfg.modelName)
-		instance.client = openai.NewClientWithConfig(config)
+	if cfg.provider == AZURE {
+		instance.client = openai.NewClientWithConfig(
+			openai.DefaultAzureConfig(cfg.token, cfg.baseURL, cfg.modelName),
+		)
 	} else {
 		c.HTTPClient = httpClient
 		instance.client = openai.NewClientWithConfig(c)

--- a/openai/options_test.go
+++ b/openai/options_test.go
@@ -1,0 +1,46 @@
+package openai
+
+import (
+	"testing"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+func Test_config_vaild(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *config
+		wantErr error
+	}{
+		{
+			name:    "test vaild",
+			cfg:     newConfig(),
+			wantErr: errorsMissingToken,
+		},
+		{
+			name: "model vaild",
+			cfg: newConfig(
+				WithToken("test"),
+				WithModel("test"),
+			),
+			wantErr: errorsMissingModel,
+		},
+		{
+			name: "missing Azure deployment model",
+			cfg: newConfig(
+				WithToken("test"),
+				WithModel(openai.GPT3Dot5Turbo),
+				WithProvider(AZURE),
+			),
+			wantErr: errorsMissingAzureModel,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.cfg
+			if err := cfg.vaild(); err != tt.wantErr {
+				t.Errorf("config.vaild() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Update `cmd/commit.go` and `cmd/review.go` to use `openai.WithProvider` instead of `openai.WithServiceProvider`
- Refactor `openai.New` to move the initialization of `cfg` to `newConfig` function
- Add `openai.WithProvider` to `openai/options.go` to set the `provider` variable
- Add `openai/options_test.go` to test the `config.vaild()` function