### PR TITLE
fix: improve code reliability and maintainability

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"html"
 	"os"
 	"path"
 	"strconv"
@@ -217,6 +218,9 @@ var commitCmd = &cobra.Command{
 			)
 			commitMessage = resp.Content
 		}
+
+		// unescape html entities in commit message
+		commitMessage = html.UnescapeString(commitMessage)
 
 		// Output commit summary data from AI
 		color.Yellow("================Commit Summary====================")

--- a/openai/options_test.go
+++ b/openai/options_test.go
@@ -13,15 +13,25 @@ func Test_config_valid(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name:    "test valid",
+			name: "valid config",
+			cfg: newConfig(
+				WithToken("test"),
+				WithModel(openai.GPT3Dot5Turbo),
+				WithProvider(OPENAI),
+			),
+			wantErr: nil,
+		},
+		{
+			name:    "missing token",
 			cfg:     newConfig(),
 			wantErr: errorsMissingToken,
 		},
 		{
-			name: "model valid",
+			name: "missing model",
 			cfg: newConfig(
 				WithToken("test"),
 				WithModel("test"),
+				WithProvider(OPENAI),
 			),
 			wantErr: errorsMissingModel,
 		},


### PR DESCRIPTION
- Add unescaping of HTML entities in commit message
- Replace one test case with two for `config_valid` function in `openai/options_test.go`

fix #62 