### PR TITLE
docs: fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This will create a `.codegpt.yaml` file in your home directory ($HOME/.config/co
 * **openai.max_tokens**: default max tokens is `300`. see reference [max_tokens](https://platform.openai.com/docs/api-reference/completions/create#completions/create-max_tokens).
 * **openai.temperature**: default temperature is `0.7`. see reference [temperature](https://platform.openai.com/docs/api-reference/completions/create#completions/create-temperature).
 * **git.diff_unified**: generate diffs with `<n>` lines of context, default is `3`.
-* **git.exclue_list**: exclude file from `git diff` command.
+* **git.exclude_list**: exclude file from `git diff` command.
 * **openai.provider**: default service provider is `openai`, you can change to `azure`.
 * **openai.model_name**: model deployment name (for azure).
 


### PR DESCRIPTION
- fix a typo in the README.md `git.exclue_list` -> `git.exclude_list`