### PR TITLE
fix: fix COMMIT_EDITMSG of worktree missing bug

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -229,11 +229,11 @@ var commitCmd = &cobra.Command{
 
 		outputFile := viper.GetString("output.file")
 		if outputFile == "" {
-			out, err := g.TopLevel()
+			out, err := g.GitDir()
 			if err != nil {
 				return err
 			}
-			outputFile = path.Join(strings.TrimSpace(out), ".git", "COMMIT_EDITMSG")
+			outputFile = path.Join(strings.TrimSpace(out), "COMMIT_EDITMSG")
 		}
 		color.Cyan("Write the commit message to " + outputFile + " file")
 		// write commit message to git staging file

--- a/git/git.go
+++ b/git/git.go
@@ -105,6 +105,18 @@ func (c *Command) topLevel() *exec.Cmd {
 	)
 }
 
+func (c *Command) gitDir() *exec.Cmd {
+	args := []string{
+		"rev-parse",
+		"--git-dir",
+	}
+
+	return exec.Command(
+		"git",
+		args...,
+	)
+}
+
 func (c *Command) commit(val string) *exec.Cmd {
 	args := []string{
 		"commit",
@@ -136,6 +148,16 @@ func (c *Command) Commit(val string) (string, error) {
 // If there is no working tree, report an error.
 func (c *Command) TopLevel() (string, error) {
 	output, err := c.topLevel().Output()
+	if err != nil {
+		return "", err
+	}
+
+	return string(output), nil
+}
+
+// GitDir to show the (by default, absolute) path of the git directory of the working tree.
+func (c *Command) GitDir() (string, error) {
+	output, err := c.gitDir().Output()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
git worktree's COMMIT_EDITMSG are stored in

repo/.git/worktrees/branch/COMMIT_EDITMSG

We should use `git rev-parse --git-dir` to get the worktree's git direcotry, and find the COMMIT_EDITMSG.

Hope this patch can fix #49.