### PR TITLE
chore: upgrade go-openai from v1.9.3 to v1.9.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/appleboy/com v0.1.7
 	github.com/fatih/color v1.15.0
-	github.com/sashabaranov/go-openai v1.9.3
+	github.com/sashabaranov/go-openai v1.9.4
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.15.0
 	golang.org/x/net v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sashabaranov/go-openai v1.9.3 h1:uNak3Rn5pPsKRs9bdT7RqRZEyej/zdZOEI2/8wvrFtM=
-github.com/sashabaranov/go-openai v1.9.3/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
+github.com/sashabaranov/go-openai v1.9.4 h1:KanoCEoowAI45jVXlenMCckutSRr39qOmSi9MyPBfZM=
+github.com/sashabaranov/go-openai v1.9.4/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
 github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -178,8 +178,12 @@ func New(opts ...Option) (*Client, error) {
 
 	// Set the OpenAI client to use the default configuration with Azure-specific options, if the provider is Azure.
 	if cfg.provider == AZURE {
+		defaultAzureConfig := openai.DefaultAzureConfig(cfg.token, cfg.baseURL)
+		defaultAzureConfig.AzureModelMapperFunc = func(model string) string {
+			return cfg.modelName
+		}
 		instance.client = openai.NewClientWithConfig(
-			openai.DefaultAzureConfig(cfg.token, cfg.baseURL, cfg.modelName),
+			defaultAzureConfig,
 		)
 	} else {
 		// Otherwise, set the OpenAI client to use the HTTP client with the specified options.


### PR DESCRIPTION
- Update go-openai dependency from v1.9.3 to v1.9.4
- Refactor defaultAzureConfig initialization with AzureModelMapperFunc in New function