### PR TITLE
feat: improve template handling and test coverage

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -29,6 +29,7 @@ var (
 	socksProxy     string
 	templateFile   string
 	templateString string
+	templateVars   []string
 	commitAmend    bool
 	timeout        time.Duration
 )
@@ -44,6 +45,7 @@ func init() {
 	commitCmd.PersistentFlags().StringVar(&socksProxy, "socks", "", "socks proxy")
 	commitCmd.PersistentFlags().StringVar(&templateFile, "template_file", "", "git commit message file")
 	commitCmd.PersistentFlags().StringVar(&templateString, "template_string", "", "git commit message string")
+	commitCmd.PersistentFlags().StringSliceVar(&templateVars, "template_vars", []string{}, "template variables")
 	commitCmd.PersistentFlags().BoolVar(&commitAmend, "amend", false, "replace the tip of the current branch by creating a new commit.")
 	commitCmd.PersistentFlags().DurationVarP(&timeout, "timeout", "t", 10*time.Second, "http timeout")
 	_ = viper.BindPFlag("output.file", commitCmd.PersistentFlags().Lookup("file"))
@@ -169,6 +171,11 @@ var commitCmd = &cobra.Command{
 			"summarize_title":   strings.TrimSpace(summarizeTitle),
 			"summarize_message": strings.TrimSpace(summarizeMessage),
 		}
+		vars := util.ConvertToMap(templateVars)
+		for k, v := range vars {
+			data[k] = v
+		}
+
 		if viper.GetString("git.template_file") != "" {
 			format, err := os.ReadFile(viper.GetString("git.template_file"))
 			if err != nil {

--- a/util/template_test.go
+++ b/util/template_test.go
@@ -22,6 +22,25 @@ func TestNewTemplateByString(t *testing.T) {
 	}
 }
 
+func TestNewTemplateByStringWithCustomVars(t *testing.T) {
+	data := map[string]interface{}{}
+	vars := ConvertToMap([]string{"Name=John Doe", "Message=Hello"})
+	for k, v := range vars {
+		data[k] = v
+	}
+
+	expected := "Hello, John Doe! Hello"
+
+	actual, err := NewTemplateByString("Hello, {{.Name}}! {{.Message}}", data)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if actual != expected {
+		t.Errorf("Expected %q but got %q", expected, actual)
+	}
+}
+
 func TestProcessTemplate(t *testing.T) {
 	// Set up test data
 	testTemplateName := "test.tmpl"

--- a/util/util.go
+++ b/util/util.go
@@ -1,9 +1,24 @@
 package util
 
-import "os/exec"
+import (
+	"os/exec"
+	"strings"
+)
 
 // IsCommandAvailable checks whether a command is available in the PATH.
 func IsCommandAvailable(cmd string) bool {
 	_, err := exec.LookPath(cmd)
 	return err == nil
+}
+
+// ConvertToMap converts a slice of strings to a map.
+func ConvertToMap(args []string) Data {
+	m := make(Data)
+	for _, arg := range args {
+		kv := strings.SplitN(arg, "=", 2)
+		if len(kv) == 2 {
+			m[kv[0]] = kv[1]
+		}
+	}
+	return m
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"os"
+	"reflect"
 	"testing"
 )
 
@@ -45,6 +46,38 @@ func TestIsCommandAvailable(t *testing.T) {
 
 			if got != tc.want {
 				t.Errorf("IsCommandAvailable(%q) = %v; want %v", tc.cmd, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestConvertToMap(t *testing.T) {
+	type args struct {
+		args []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want Data
+	}{
+		{
+			name: "convert slice to map",
+			args: args{
+				[]string{
+					"TICKET_ID=ABC-1234",
+					"Name=John Doe",
+				},
+			},
+			want: Data{
+				"Name":      "John Doe",
+				"TICKET_ID": "ABC-1234",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ConvertToMap(tt.args.args); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ConvertToMap() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
- Add `templateVars` flag to `commitCmd`
- Implement `ConvertToMap` function to convert a slice of strings to a map
- Add test for `NewTemplateByStringWithCustomVars`
- Add test for `ConvertToMap`

ref #72 