### PR TITLE
docs: enhance commit message customization and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,34 @@ change format with template file using `--template_file` parameter:
 codegpt commit --preview --template_file your_file_path
 ```
 
+Add custom variable to git commit message template:
+
+```sh
+{{ .summarize_prefix }}: {{ .summarize_title }}
+
+{{ .summarize_message }}
+
+{{ if .JIRA_URL }}{{ .JIRA_URL }}{{ end }}
+```
+
+Add custom variable to git commit message template using `--template_vars` paratemter:
+
+```sh
+codegpt commit --preview --template_file your_file_path --template_vars JIRA_URL=https://jira.example.com/ABC-123
+```
+
+Load custom variable from file using `--template_vars_file` paratemter:
+
+```sh
+codegpt commit --preview --template_file your_file_path --template_vars_file your_file_path
+```
+
+See the `template_vars_file` format as following:
+
+```env
+JIRA_URL=https://jira.example.com/ABC-123
+```
+
 ### Git hook
 
 You can also use the prepare-commit-msg hook to integrate `codegpt` with Git. This allows you to use Git normally and edit the commit message before committing.

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Default commit message template as following:
 {{ .summarize_message }}
 ```
 
-change format with template string using `--template_string` paratemter:
+change format with template string using `--template_string` parameter:
 
 ```sh
 codegpt commit --preview --template_string \
@@ -193,13 +193,13 @@ Add custom variable to git commit message template:
 {{ if .JIRA_URL }}{{ .JIRA_URL }}{{ end }}
 ```
 
-Add custom variable to git commit message template using `--template_vars` paratemter:
+Add custom variable to git commit message template using `--template_vars` parameter:
 
 ```sh
 codegpt commit --preview --template_file your_file_path --template_vars JIRA_URL=https://jira.example.com/ABC-123
 ```
 
-Load custom variable from file using `--template_vars_file` paratemter:
+Load custom variable from file using `--template_vars_file` parameter:
 
 ```sh
 codegpt commit --preview --template_file your_file_path --template_vars_file your_file_path


### PR DESCRIPTION
- Add instructions for adding custom variables to git commit message template
- Explain usage of `--template_vars` and `--template_vars_file` parameters
- Provide examples of custom variable usage and template_vars_file format

fix #72 