### PR TITLE
fix: convert openai.timeout to nanoseconds in calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This will create a `.codegpt.yaml` file in your home directory ($HOME/.config/co
 * **openai.model**: default model is `gpt-3.5-turbo`, you can change to `gpt-4` or [other available model list](https://github.com/appleboy/CodeGPT/blob/bf28f000463cfc6dfa2572df61e1b160c5c680f7/openai/openai.go#L18-L38).
 * **openai.proxy**: http/https client proxy.
 * **openai.socks**: socks client proxy.
-* **openai.timeout**: default http timeout is `10s` (ten seconds).
+* **openai.timeout**: default http timeout is `30s` (thirty seconds).
 * **openai.max_tokens**: default max tokens is `300`. see reference [max_tokens](https://platform.openai.com/docs/api-reference/completions/create#completions/create-max_tokens).
 * **openai.temperature**: default temperature is `0.7`. see reference [temperature](https://platform.openai.com/docs/api-reference/completions/create#completions/create-temperature).
 * **git.diff_unified**: generate diffs with `<n>` lines of context, default is `3`.

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -74,7 +74,7 @@ var commitCmd = &cobra.Command{
 		}
 
 		// Update the OpenAI client request timeout if the timeout value is greater than the default openai.timeout
-		if timeout > viper.GetDuration("openai.timeout") {
+		if timeout > viper.GetDuration("openai.timeout")*time.Second {
 			viper.Set("openai.timeout", timeout)
 		}
 
@@ -91,7 +91,7 @@ var commitCmd = &cobra.Command{
 			openai.WithProxyURL(viper.GetString("openai.proxy")),
 			openai.WithSocksURL(viper.GetString("openai.socks")),
 			openai.WithBaseURL(viper.GetString("openai.base_url")),
-			openai.WithTimeout(viper.GetDuration("openai.timeout")),
+			openai.WithTimeout(viper.GetDuration("openai.timeout")*time.Second),
 			openai.WithMaxTokens(viper.GetInt("openai.max_tokens")),
 			openai.WithTemperature(float32(viper.GetFloat64("openai.temperature"))),
 			openai.WithProvider(viper.GetString("openai.provider")),

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -51,7 +51,7 @@ func init() {
 	commitCmd.PersistentFlags().StringSliceVar(&templateVars, "template_vars", []string{}, "template variables")
 	commitCmd.PersistentFlags().StringVar(&templateVarsFile, "template_vars_file", "", "template variables file")
 	commitCmd.PersistentFlags().BoolVar(&commitAmend, "amend", false, "replace the tip of the current branch by creating a new commit.")
-	commitCmd.PersistentFlags().DurationVarP(&timeout, "timeout", "t", 10*time.Second, "http timeout")
+	commitCmd.PersistentFlags().DurationVarP(&timeout, "timeout", "t", 30, "http timeout")
 	_ = viper.BindPFlag("output.file", commitCmd.PersistentFlags().Lookup("file"))
 }
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -2,13 +2,11 @@ package cmd
 
 import (
 	"errors"
-	"strings"
-	"time"
-
 	"github.com/appleboy/com/array"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"strings"
 )
 
 var availableKeys = []string{
@@ -38,7 +36,7 @@ func init() {
 	configCmd.PersistentFlags().StringP("org_id", "o", "", "openai requesting organization")
 	configCmd.PersistentFlags().StringP("proxy", "", "", "http proxy")
 	configCmd.PersistentFlags().StringP("socks", "", "", "socks proxy")
-	configCmd.PersistentFlags().DurationP("timeout", "t", 10*time.Second, "http timeout")
+	configCmd.PersistentFlags().DurationP("timeout", "t", 30, "http timeout")
 	configCmd.PersistentFlags().StringP("template_file", "", "", "git commit message file")
 	configCmd.PersistentFlags().StringP("template_string", "", "", "git commit message string")
 	configCmd.PersistentFlags().IntP("diff_unified", "", 3, "generate diffs with <n> lines of context, default is 3")

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -1,13 +1,13 @@
 package cmd
 
 import (
-	"strconv"
-	"strings"
-
 	"github.com/appleboy/CodeGPT/git"
 	"github.com/appleboy/CodeGPT/openai"
 	"github.com/appleboy/CodeGPT/prompt"
 	"github.com/appleboy/CodeGPT/util"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -53,7 +53,7 @@ var reviewCmd = &cobra.Command{
 			openai.WithProxyURL(viper.GetString("openai.proxy")),
 			openai.WithSocksURL(viper.GetString("openai.socks")),
 			openai.WithBaseURL(viper.GetString("openai.base_url")),
-			openai.WithTimeout(viper.GetDuration("openai.timeout")),
+			openai.WithTimeout(viper.GetDuration("openai.timeout")*time.Second),
 			openai.WithMaxTokens(viper.GetInt("openai.max_tokens")),
 			openai.WithTemperature(float32(viper.GetFloat64("openai.temperature"))),
 			openai.WithProvider(viper.GetString("openai.provider")),


### PR DESCRIPTION
The docs says openai.timeout defaults to 10s, which implies the unit of the parameter should be seconds. However, if the output language is not English (e.g. zh-tw), it times out immediately. It is because the default unit for durations is nanoseconds. This commit help convert the units.