### PR TITLE
feat(model): add support for OpenAI API version configuration

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -100,6 +100,7 @@ var commitCmd = &cobra.Command{
 			openai.WithModelName(viper.GetString("openai.model_name")),
 			openai.WithSkipVerify(viper.GetBool("openai.skip_verify")),
 			openai.WithHeaders(viper.GetStringSlice("openai.headers")),
+			openai.WithApiVersion(viper.GetString("openai.api_version")),
 		)
 		if err != nil && !promptOnly {
 			return err

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -30,6 +30,7 @@ var availableKeys = []string{
 	"openai.model_name",
 	"openai.skip_verify",
 	"openai.headers",
+	"openai.api_version",
 }
 
 func init() {
@@ -52,6 +53,7 @@ func init() {
 	configCmd.PersistentFlags().StringP("model_name", "", "", "model deployment name for Azure cognitive service")
 	configCmd.PersistentFlags().BoolP("skip_verify", "", false, "skip verify TLS certificate")
 	configCmd.PersistentFlags().StringP("headers", "", "", "custom headers for openai request")
+	configCmd.PersistentFlags().StringP("api_version", "", "", "openai api version")
 
 	_ = viper.BindPFlag("openai.base_url", configCmd.PersistentFlags().Lookup("base_url"))
 	_ = viper.BindPFlag("openai.org_id", configCmd.PersistentFlags().Lookup("org_id"))
@@ -72,6 +74,7 @@ func init() {
 	_ = viper.BindPFlag("openai.model_name", configCmd.PersistentFlags().Lookup("model_name"))
 	_ = viper.BindPFlag("openai.skip_verify", configCmd.PersistentFlags().Lookup("skip_verify"))
 	_ = viper.BindPFlag("openai.headers", configCmd.PersistentFlags().Lookup("headers"))
+	_ = viper.BindPFlag("openai.api_version", configCmd.PersistentFlags().Lookup("api_version"))
 }
 
 var configCmd = &cobra.Command{

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -60,6 +60,7 @@ var reviewCmd = &cobra.Command{
 			openai.WithModelName(viper.GetString("openai.model_name")),
 			openai.WithSkipVerify(viper.GetBool("openai.skip_verify")),
 			openai.WithHeaders(viper.GetStringSlice("openai.headers")),
+			openai.WithApiVersion(viper.GetString("openai.api_version")),
 		)
 		if err != nil {
 			return err

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -202,6 +202,10 @@ func New(opts ...Option) (*Client, error) {
 		defaultAzureConfig.AzureModelMapperFunc = func(model string) string {
 			return cfg.modelName
 		}
+		// Set the API version to the one with the specified options.
+		if cfg.apiVersion != "" {
+			defaultAzureConfig.APIVersion = cfg.apiVersion
+		}
 		// Set the HTTP client to the one with the specified options.
 		defaultAzureConfig.HTTPClient = httpClient
 		instance.client = openai.NewClientWithConfig(
@@ -210,6 +214,9 @@ func New(opts ...Option) (*Client, error) {
 	} else {
 		// Otherwise, set the OpenAI client to use the HTTP client with the specified options.
 		c.HTTPClient = httpClient
+		if cfg.apiVersion != "" {
+			c.APIVersion = cfg.apiVersion
+		}
 		instance.client = openai.NewClientWithConfig(c)
 	}
 

--- a/openai/options.go
+++ b/openai/options.go
@@ -160,6 +160,13 @@ func WithHeaders(headers []string) Option {
 	})
 }
 
+// WithApiVersion returns a new Option that sets the apiVersion for OpenAI Model.
+func WithApiVersion(apiVersion string) Option {
+	return optionFunc(func(c *config) {
+		c.apiVersion = apiVersion
+	})
+}
+
 // config is a struct that stores configuration options for the instrumentation.
 type config struct {
 	baseURL     string
@@ -176,6 +183,7 @@ type config struct {
 	modelName  string
 	skipVerify bool
 	headers    []string
+	apiVersion string
 }
 
 // valid checks whether a config object is valid, returning an error if it is not.


### PR DESCRIPTION
- Add `openai.WithApiVersion(viper.GetString("openai.api_version"))` to `cmd/commit.go`
- Add `openai.api_version` to `cmd/config.go`
- Add `openai.WithApiVersion(viper.GetString("openai.api_version"))` to `cmd/review.go`
- Add `cfg.apiVersion` to `openai/openai.go`
- Add `WithApiVersion(apiVersion string)` to `openai/options.go`

fix #94 