### PR TITLE
fix: fix the max_tokens is fixed at 300 in commitCmd

### DIFF
--- a/cmd/hepler.go
+++ b/cmd/hepler.go
@@ -43,7 +43,7 @@ func check() error {
 		viper.Set("openai.socks", socksProxy)
 	}
 
-	if maxTokens != 0 {
+	if maxTokens != 300 {
 		viper.Set("openai.max_tokens", maxTokens)
 	}
 


### PR DESCRIPTION
fix the default value (300) of maxTokens in reviewCmd, as it causes a bug in commitCmd where the max_tokens is fixed at 300