### PR TITLE
Support for multiple azure deployment model name Settings

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -97,7 +97,12 @@ var commitCmd = &cobra.Command{
 			openai.WithMaxTokens(viper.GetInt("openai.max_tokens")),
 			openai.WithTemperature(float32(viper.GetFloat64("openai.temperature"))),
 			openai.WithProvider(viper.GetString("openai.provider")),
-			openai.WithModelName(viper.GetString("openai.model_name")),
+			openai.WithAzureModelMapperFunc(func(azureModel string) string {
+				azureModelMapping := map[string]string{
+					viper.GetString("openai.model"): viper.GetString("openai.model_name"),
+				}
+				return azureModelMapping[azureModel]
+			}),
 			openai.WithSkipVerify(viper.GetBool("openai.skip_verify")),
 			openai.WithHeaders(viper.GetStringSlice("openai.headers")),
 			openai.WithApiVersion(viper.GetString("openai.api_version")),

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -57,7 +57,12 @@ var reviewCmd = &cobra.Command{
 			openai.WithMaxTokens(viper.GetInt("openai.max_tokens")),
 			openai.WithTemperature(float32(viper.GetFloat64("openai.temperature"))),
 			openai.WithProvider(viper.GetString("openai.provider")),
-			openai.WithModelName(viper.GetString("openai.model_name")),
+			openai.WithAzureModelMapperFunc(func(azureModel string) string {
+				azureModelMapping := map[string]string{
+					viper.GetString("openai.model"): viper.GetString("openai.model_name"),
+				}
+				return azureModelMapping[azureModel]
+			}),
 			openai.WithSkipVerify(viper.GetBool("openai.skip_verify")),
 			openai.WithHeaders(viper.GetStringSlice("openai.headers")),
 			openai.WithApiVersion(viper.GetString("openai.api_version")),

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -196,9 +196,16 @@ func New(opts ...Option) (*Client, error) {
 	// Set the OpenAI client to use the default configuration with Azure-specific options, if the provider is Azure.
 	if cfg.provider == AZURE {
 		defaultAzureConfig := openai.DefaultAzureConfig(cfg.token, cfg.baseURL)
-		defaultAzureConfig.AzureModelMapperFunc = func(model string) string {
-			return cfg.modelName
+		var azureModelMapperFunc func(string) string
+		if cfg.modelName != "" {
+			azureModelMapperFunc = func(model string) string {
+				return cfg.modelName
+			}
 		}
+		if cfg.azureModelMapperFunc != nil {
+			azureModelMapperFunc = cfg.azureModelMapperFunc
+		}
+		defaultAzureConfig.AzureModelMapperFunc = azureModelMapperFunc
 		// Set the API version to the one with the specified options.
 		if cfg.apiVersion != "" {
 			defaultAzureConfig.APIVersion = cfg.apiVersion

--- a/openai/options.go
+++ b/openai/options.go
@@ -223,7 +223,7 @@ func (cfg *config) valid() error {
 	}
 
 	// If the provider is Azure, check that the model name or azureModelMapperFunc is not empty.
-	if cfg.provider == AZURE && cfg.modelName == "" && cfg.azureModelMapperFunc != nil {
+	if cfg.provider == AZURE && cfg.modelName == "" && cfg.azureModelMapperFunc == nil {
 		return errorsMissingAzureModel
 	}
 


### PR DESCRIPTION
While only the chat model is required, it is more general to support multiple model deployments.