### PR TITLE
feat: refactor completion function and add CreateFunctionCall function

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -198,11 +198,16 @@ var commitCmd = &cobra.Command{
 				return err
 			}
 			color.Cyan("We are trying to get conventional commit prefix")
-			resp, err := client.Completion(cmd.Context(), out)
+			resp, err := client.CreateFunctionCall(cmd.Context(), out, openai.SummaryPrefixFunc)
 			if err != nil {
 				return err
 			}
-			data[prompt.SummarizePrefixKey] = strings.TrimSpace(resp.Content)
+			summaryPrix := ""
+			if len(resp.Choices) > 0 {
+				args := openai.GetSummaryPrefixArgs(resp.Choices[0].Message.FunctionCall.Arguments)
+				summaryPrix = args.Prefix
+			}
+			data[prompt.SummarizePrefixKey] = summaryPrix
 			color.Magenta("PromptTokens: " + strconv.Itoa(resp.Usage.PromptTokens) +
 				", CompletionTokens: " + strconv.Itoa(resp.Usage.CompletionTokens) +
 				", TotalTokens: " + strconv.Itoa(resp.Usage.TotalTokens),

--- a/openai/func.go
+++ b/openai/func.go
@@ -1,0 +1,44 @@
+package openai
+
+import (
+	"encoding/json"
+
+	"github.com/appleboy/com/bytesconv"
+	openai "github.com/sashabaranov/go-openai"
+	"github.com/sashabaranov/go-openai/jsonschema"
+)
+
+// SummaryPrefixFunc is a openai function definition.
+var SummaryPrefixFunc = openai.FunctionDefinition{
+	Name: "get_summary_prefix",
+	Parameters: jsonschema.Definition{
+		Type: jsonschema.Object,
+		Properties: map[string]jsonschema.Definition{
+			"prefix": {
+				Type: jsonschema.String,
+				Enum: []string{
+					"build", "chore", "ci",
+					"docs", "feat", "fix",
+					"perf", "refactor", "style",
+					"test",
+				},
+			},
+		},
+		Required: []string{"prefix"},
+	},
+}
+
+// SummaryPrefixParams is a struct that stores configuration options for the get_summary_prefix function.
+type SummaryPrefixParams struct {
+	Prefix string `json:"prefix"`
+}
+
+// GetSummaryPrefixArgs returns the SummaryPrefixParams struct corresponding to the given JSON data.
+func GetSummaryPrefixArgs(data string) SummaryPrefixParams {
+	var prefix SummaryPrefixParams
+	err := json.Unmarshal(bytesconv.StrToBytes(data), &prefix)
+	if err != nil {
+		panic(err)
+	}
+	return prefix
+}

--- a/openai/func_test.go
+++ b/openai/func_test.go
@@ -1,0 +1,20 @@
+package openai
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetSummaryPrefixArgs(t *testing.T) {
+	data := `{"prefix": "feat", "param2": "value2"}`
+
+	result := GetSummaryPrefixArgs(data)
+
+	expected := SummaryPrefixParams{
+		Prefix: "feat",
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %v, but got %v", expected, result)
+	}
+}

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -61,6 +61,29 @@ type Response struct {
 	Usage   openai.Usage
 }
 
+// CreateChatCompletion is an API call to create a function call for a chat message.
+func (c *Client) CreateFunctionCall(
+	ctx context.Context,
+	content string,
+	funcs ...openai.FunctionDefinition,
+) (resp openai.ChatCompletionResponse, err error) {
+	req := openai.ChatCompletionRequest{
+		Model:       c.model,
+		MaxTokens:   c.maxTokens,
+		Temperature: c.temperature,
+		TopP:        1,
+		Messages: []openai.ChatCompletionMessage{
+			{
+				Role:    openai.ChatMessageRoleUser,
+				Content: content,
+			},
+		},
+		Functions:    funcs,
+		FunctionCall: "auto",
+	}
+	return c.client.CreateChatCompletion(ctx, req)
+}
+
 // CreateChatCompletion is an API call to create a completion for a chat message.
 func (c *Client) CreateChatCompletion(
 	ctx context.Context,


### PR DESCRIPTION
fix #96 
fix https://github.com/appleboy/CodeGPT/issues/91

- Modify `cmd/commit.go`
  - Change the `client.Completion` function call to `client.CreateFunctionCall`
  - Update the assignment of `data[prompt.SummarizePrefixKey]`
  - Add a new variable `summaryPrix` and assign it based on the choices in `resp`
- Add a new file `openai/func.go`
- Add a new file `openai/func_test.go`
- Modify `openai/openai.go`
  - Add a new function `CreateFunctionCall`