### PR TITLE
refactor: add support for function calls in summarization

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -243,3 +243,15 @@ func New(opts ...Option) (*Client, error) {
 	// Return the resulting client instance.
 	return instance, nil
 }
+
+// AllowFuncCall returns true if the model supports function calls.
+// In an API call, you can describe functions to gpt-3.5-turbo-0613 and gpt-4-0613
+// https://platform.openai.com/docs/guides/gpt/chat-completions-api
+func (c *Client) AllowFuncCall() bool {
+	switch c.model {
+	case openai.GPT432K0613, openai.GPT40613, openai.GPT3Dot5Turbo0613, openai.GPT3Dot5Turbo16K0613:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
- Modify the `commit.go` file:
  - Add a new variable `summaryPrix` and initialize it as an empty string
  - If `client.AllowFuncCall()` is true, make a function call to `openai.SummaryPrefixFunc` and assign the response to `resp`
  - If `resp.Choices` has more than 0 elements, extract the prefix from the arguments and assign it to `summaryPrix`
  - Set `data[prompt.SummarizePrefixKey]` to `summaryPrix`
  - If `client.AllowFuncCall()` is false, make a completion call and assign the response to `resp`
  - Trim the content of `resp` and assign it to `summaryPrix`
  - Set `data[prompt.SummarizePrefixKey]` to `summaryPrix`
- Modify the `openai.go` file:
  - Add a new function `AllowFuncCall()` that returns true if the model supports function calls

ref: #91 