### PR TITLE
chore: update CodeGPT version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The pre-compiled binaries can be downloaded from [release page](https://github.c
 
 ```sh
 $ codegpt version
-version: v0.1.6 commit: xxxxxxx
+version: v0.4.3 commit: xxxxxxx
 ```
 
 ## Setup


### PR DESCRIPTION
- Changed displayed version from v0.1.6 to v0.4.3.
- Perhaps "v0.4.x" for future references? Although, maybe more convenient but less pretty.