### PR TITLE
chore: add OpenAI configuration options to commit command

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -101,6 +101,9 @@ var commitCmd = &cobra.Command{
 			openai.WithSkipVerify(viper.GetBool("openai.skip_verify")),
 			openai.WithHeaders(viper.GetStringSlice("openai.headers")),
 			openai.WithApiVersion(viper.GetString("openai.api_version")),
+			openai.WithTopP(float32(viper.GetFloat64("openai.top_p"))),
+			openai.WithFrequencyPenalty(float32(viper.GetFloat64("openai.frequency_penalty"))),
+			openai.WithPresencePenalty(float32(viper.GetFloat64("openai.presence_penalty"))),
 		)
 		if err != nil && !promptOnly {
 			return err

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -31,6 +31,9 @@ var availableKeys = []string{
 	"openai.skip_verify",
 	"openai.headers",
 	"openai.api_version",
+	"openai.top_p",
+	"openai.frequency_penalty",
+	"openai.presence_penalty",
 }
 
 func init() {
@@ -47,6 +50,9 @@ func init() {
 	configCmd.PersistentFlags().IntP("diff_unified", "", 3, "generate diffs with <n> lines of context, default is 3")
 	configCmd.PersistentFlags().IntP("max_tokens", "", 300, "the maximum number of tokens to generate in the chat completion.")
 	configCmd.PersistentFlags().Float32P("temperature", "", 0.7, "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.")
+	configCmd.PersistentFlags().Float32P("top_p", "", 1.0, "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.")
+	configCmd.PersistentFlags().Float32P("frequency_penalty", "", 0.0, "Number between 0.0 and 1.0 that penalizes new tokens based on their existing frequency in the text so far. Decreases the model's likelihood to repeat the same line verbatim.")
+	configCmd.PersistentFlags().Float32P("presence_penalty", "", 0.0, "Number between 0.0 and 1.0 that penalizes new tokens based on whether they appear in the text so far. Increases the model's likelihood to talk about new topics.")
 	configCmd.PersistentFlags().StringP("exclude_list", "", "", "exclude file from `git diff` command")
 
 	configCmd.PersistentFlags().StringP("provider", "", "openai", "service provider, only support 'openai' or 'azure'")

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -61,6 +61,9 @@ var reviewCmd = &cobra.Command{
 			openai.WithSkipVerify(viper.GetBool("openai.skip_verify")),
 			openai.WithHeaders(viper.GetStringSlice("openai.headers")),
 			openai.WithApiVersion(viper.GetString("openai.api_version")),
+			openai.WithTopP(float32(viper.GetFloat64("openai.top_p"))),
+			openai.WithFrequencyPenalty(float32(viper.GetFloat64("openai.frequency_penalty"))),
+			openai.WithPresencePenalty(float32(viper.GetFloat64("openai.presence_penalty"))),
 		)
 		if err != nil {
 			return err

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -55,6 +55,19 @@ type Client struct {
 	maxTokens   int
 	temperature float32
 	isFuncCall  bool
+
+	// An alternative to sampling with temperature, called nucleus sampling,
+	// where the model considers the results of the tokens with top_p probability mass.
+	// So 0.1 means only the tokens comprising the top 10% probability mass are considered.
+	topP float32
+	// Number between -2.0 and 2.0.
+	// Positive values penalize new tokens based on whether they appear in the text so far,
+	// increasing the model's likelihood to talk about new topics.
+	presencePenalty float32
+	// Number between -2.0 and 2.0.
+	// Positive values penalize new tokens based on their existing frequency in the text so far,
+	// decreasing the model's likelihood to repeat the same line verbatim.
+	frequencyPenalty float32
 }
 
 type Response struct {
@@ -69,10 +82,12 @@ func (c *Client) CreateFunctionCall(
 	funcs ...openai.FunctionDefinition,
 ) (resp openai.ChatCompletionResponse, err error) {
 	req := openai.ChatCompletionRequest{
-		Model:       c.model,
-		MaxTokens:   c.maxTokens,
-		Temperature: c.temperature,
-		TopP:        1,
+		Model:            c.model,
+		MaxTokens:        c.maxTokens,
+		Temperature:      c.temperature,
+		TopP:             c.topP,
+		FrequencyPenalty: c.frequencyPenalty,
+		PresencePenalty:  c.presencePenalty,
 		Messages: []openai.ChatCompletionMessage{
 			{
 				Role:    openai.ChatMessageRoleUser,
@@ -91,10 +106,12 @@ func (c *Client) CreateChatCompletion(
 	content string,
 ) (resp openai.ChatCompletionResponse, err error) {
 	req := openai.ChatCompletionRequest{
-		Model:       c.model,
-		MaxTokens:   c.maxTokens,
-		Temperature: c.temperature,
-		TopP:        1,
+		Model:            c.model,
+		MaxTokens:        c.maxTokens,
+		Temperature:      c.temperature,
+		TopP:             c.topP,
+		FrequencyPenalty: c.frequencyPenalty,
+		PresencePenalty:  c.presencePenalty,
 		Messages: []openai.ChatCompletionMessage{
 			{
 				Role:    openai.ChatMessageRoleUser,
@@ -117,11 +134,13 @@ func (c *Client) CreateCompletion(
 	content string,
 ) (resp openai.CompletionResponse, err error) {
 	req := openai.CompletionRequest{
-		Model:       c.model,
-		MaxTokens:   c.maxTokens,
-		Temperature: c.temperature,
-		TopP:        1,
-		Prompt:      content,
+		Model:            c.model,
+		MaxTokens:        c.maxTokens,
+		Temperature:      c.temperature,
+		TopP:             c.topP,
+		FrequencyPenalty: c.frequencyPenalty,
+		PresencePenalty:  c.presencePenalty,
+		Prompt:           content,
 	}
 
 	return c.client.CreateCompletion(ctx, req)

--- a/openai/options.go
+++ b/openai/options.go
@@ -23,6 +23,7 @@ const (
 	defaultModel       = openai.GPT3Dot5Turbo
 	defaultTemperature = 0.7
 	defaultProvider    = OPENAI
+	defaultTopP        = 1.0
 )
 
 // Option is an interface that specifies instrumentation configuration options.
@@ -167,6 +168,27 @@ func WithApiVersion(apiVersion string) Option {
 	})
 }
 
+// WithTopP returns a new Option that sets the topP for the client configuration.
+func WithTopP(val float32) Option {
+	return optionFunc(func(c *config) {
+		c.topP = val
+	})
+}
+
+// WithPresencePenalty returns a new Option that sets the presencePenalty for the client configuration.
+func WithPresencePenalty(val float32) Option {
+	return optionFunc(func(c *config) {
+		c.presencePenalty = val
+	})
+}
+
+// WithFrequencyPenalty returns a new Option that sets the frequencyPenalty for the client configuration.
+func WithFrequencyPenalty(val float32) Option {
+	return optionFunc(func(c *config) {
+		c.frequencyPenalty = val
+	})
+}
+
 // config is a struct that stores configuration options for the instrumentation.
 type config struct {
 	baseURL     string
@@ -178,6 +200,10 @@ type config struct {
 	timeout     time.Duration
 	maxTokens   int
 	temperature float32
+
+	topP             float32
+	presencePenalty  float32
+	frequencyPenalty float32
 
 	provider   string
 	modelName  string
@@ -216,6 +242,7 @@ func newConfig(opts ...Option) *config {
 		maxTokens:   defaultMaxTokens,
 		temperature: defaultTemperature,
 		provider:    defaultProvider,
+		topP:        defaultTopP,
 	}
 
 	// Apply each of the given options to the config object.


### PR DESCRIPTION
- Add `openai.WithTopP(float32(viper.GetFloat64("openai.top_p")))` to `commit.go`
- Add `openai.WithFrequencyPenalty(float32(viper.GetFloat64("openai.frequency_penalty")))` to `commit.go`
- Add `openai.WithPresencePenalty(float32(viper.GetFloat64("openai.presence_penalty")))` to `commit.go`
- Add `openai.top_p` to `availableKeys` in `config.go`
- Add `openai.frequency_penalty` to `availableKeys` in `config.go`
- Add `openai.presence_penalty` to `availableKeys` in `config.go`
- Add `configCmd.PersistentFlags().Float32P("top_p", "", 1.0, "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.")` to `config.go`
- Add `configCmd.PersistentFlags().Float32P("frequency_penalty", "", 0.0, "Number between 0.0 and 1.0 that penalizes new tokens based on their existing frequency in the text so far. Decreases the model's likelihood to repeat the same line verbatim.")` to `config.go`
- Add `configCmd.PersistentFlags().Float32P("presence_penalty", "", 0

ref #120 