### PR TITLE
chore(timeout): update default timeout to 30 seconds across files

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -36,6 +36,8 @@ var (
 
 	templateVars     []string
 	templateVarsFile string
+
+	defaultTimeout = 30 * time.Second
 )
 
 func init() {
@@ -52,7 +54,7 @@ func init() {
 	commitCmd.PersistentFlags().StringSliceVar(&templateVars, "template_vars", []string{}, "template variables")
 	commitCmd.PersistentFlags().StringVar(&templateVarsFile, "template_vars_file", "", "template variables file")
 	commitCmd.PersistentFlags().BoolVar(&commitAmend, "amend", false, "replace the tip of the current branch by creating a new commit.")
-	commitCmd.PersistentFlags().DurationVarP(&timeout, "timeout", "t", 10*time.Second, "http timeout")
+	commitCmd.PersistentFlags().DurationVarP(&timeout, "timeout", "t", defaultTimeout, "request timeout")
 	commitCmd.PersistentFlags().BoolVar(&promptOnly, "prompt_only", false, "show prompt only, don't send request to openai")
 	_ = viper.BindPFlag("output.file", commitCmd.PersistentFlags().Lookup("file"))
 }
@@ -76,7 +78,8 @@ var commitCmd = &cobra.Command{
 		}
 
 		// Update the OpenAI client request timeout if the timeout value is greater than the default openai.timeout
-		if timeout > viper.GetDuration("openai.timeout") {
+		if timeout > viper.GetDuration("openai.timeout") ||
+			timeout != defaultTimeout {
 			viper.Set("openai.timeout", timeout)
 		}
 

--- a/cmd/config_list.go
+++ b/cmd/config_list.go
@@ -26,7 +26,7 @@ var availableKeys = map[string]string{
 	"openai.proxy":             "http proxy",
 	"output.lang":              "summarizing language uses English by default",
 	"openai.base_url":          "what API base url to use.",
-	"openai.timeout":           "http timeout",
+	"openai.timeout":           "request timeout",
 	"openai.max_tokens":        "the maximum number of tokens to generate in the chat completion.",
 	"openai.temperature":       "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.",
 	"openai.provider":          "service provider, only support 'openai' or 'azure'",

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"strings"
-	"time"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -19,7 +18,7 @@ func init() {
 	configSetCmd.Flags().StringP("org_id", "o", "", availableKeys["openai.org_id"])
 	configSetCmd.Flags().StringP("proxy", "", "", availableKeys["openai.proxy"])
 	configSetCmd.Flags().StringP("socks", "", "", availableKeys["openai.socks"])
-	configSetCmd.Flags().DurationP("timeout", "t", 10*time.Second, availableKeys["openai.timeout"])
+	configSetCmd.Flags().DurationP("timeout", "t", defaultTimeout, availableKeys["openai.timeout"])
 	configSetCmd.Flags().StringP("template_file", "", "", availableKeys["git.template_file"])
 	configSetCmd.Flags().StringP("template_string", "", "", availableKeys["git.template_string"])
 	configSetCmd.Flags().IntP("diff_unified", "", 3, availableKeys["git.diff_unified"])


### PR DESCRIPTION
- Increase the default timeout to `30` seconds
- Change the default timeout to `30` seconds in the `commitCmd` function
- Change the `availableKeys` map value for `openai.timeout` from `http timeout` to `request timeout`
- Remove the import of `time` in the `cmd/config_set.go` file
- Change the default timeout to `30` seconds in the `configSetCmd` function

fixed https://github.com/appleboy/CodeGPT/pull/92