### PR TITLE
feat(git): don't use codegpt if user supplies message with `git commit -m`

### DIFF
--- a/git/templates/prepare-commit-msg
+++ b/git/templates/prepare-commit-msg
@@ -1,3 +1,5 @@
 #!/bin/sh
 
-[[ "$2" != "message" ]] && codegpt commit --file $1 --preview
+if [[ "$2" != "message" ]]; then
+    codegpt commit --file $1 --preview
+fi

--- a/git/templates/prepare-commit-msg
+++ b/git/templates/prepare-commit-msg
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-codegpt commit --file $1 --preview
+[[ "$2" != "message" ]] && codegpt commit --file $1 --preview


### PR DESCRIPTION
This is a very simple feature that, if you `codegpt hook install` and later on, you want to use `git commit -m <custom_message>` would use that specified message. I think this is useful especially for automated deployments and releases where the  <custom_message> is really important to not change.