### PR TITLE
build: refactor codebase and improve security

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,38 @@
+linters:
+  enable-all: false
+  disable-all: true
+  fast: false
+  enable:
+    - bodyclose
+    - dogsled
+    - dupl
+    - errcheck
+    - exportloopref
+    - exhaustive
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - rowserrcheck
+    - staticcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - whitespace
+    - gofumpt
+run:
+  timeout: 3m

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -44,19 +44,23 @@ var (
 func init() {
 	commitCmd.PersistentFlags().StringP("file", "f", "", "commit message file")
 	commitCmd.PersistentFlags().BoolVar(&preview, "preview", false, "preview commit message")
-	commitCmd.PersistentFlags().IntVar(&diffUnified, "diff_unified", 3, "generate diffs with <n> lines of context, default is 3")
+	commitCmd.PersistentFlags().IntVar(&diffUnified, "diff_unified", 3,
+		"generate diffs with <n> lines of context, default is 3")
 	commitCmd.PersistentFlags().StringVar(&commitModel, "model", "gpt-3.5-turbo", "select openai model")
 	commitCmd.PersistentFlags().StringVar(&commitLang, "lang", "en", "summarizing language uses English by default")
-	commitCmd.PersistentFlags().StringSliceVar(&excludeList, "exclude_list", []string{}, "exclude file from git diff command")
+	commitCmd.PersistentFlags().StringSliceVar(&excludeList, "exclude_list", []string{},
+		"exclude file from git diff command")
 	commitCmd.PersistentFlags().StringVar(&httpsProxy, "proxy", "", "http proxy")
 	commitCmd.PersistentFlags().StringVar(&socksProxy, "socks", "", "socks proxy")
 	commitCmd.PersistentFlags().StringVar(&templateFile, "template_file", "", "git commit message file")
 	commitCmd.PersistentFlags().StringVar(&templateString, "template_string", "", "git commit message string")
 	commitCmd.PersistentFlags().StringSliceVar(&templateVars, "template_vars", []string{}, "template variables")
 	commitCmd.PersistentFlags().StringVar(&templateVarsFile, "template_vars_file", "", "template variables file")
-	commitCmd.PersistentFlags().BoolVar(&commitAmend, "amend", false, "replace the tip of the current branch by creating a new commit.")
+	commitCmd.PersistentFlags().BoolVar(&commitAmend, "amend", false,
+		"replace the tip of the current branch by creating a new commit.")
 	commitCmd.PersistentFlags().DurationVarP(&timeout, "timeout", "t", defaultTimeout, "request timeout")
-	commitCmd.PersistentFlags().BoolVar(&promptOnly, "prompt_only", false, "show prompt only, don't send request to openai")
+	commitCmd.PersistentFlags().BoolVar(&promptOnly, "prompt_only", false,
+		"show prompt only, don't send request to openai")
 	_ = viper.BindPFlag("output.file", commitCmd.PersistentFlags().Lookup("file"))
 }
 
@@ -86,24 +90,7 @@ var commitCmd = &cobra.Command{
 
 		currentModel := viper.GetString("openai.model")
 		color.Green("Summarize the commit message use " + currentModel + " model")
-		client, err := openai.New(
-			openai.WithToken(viper.GetString("openai.api_key")),
-			openai.WithModel(viper.GetString("openai.model")),
-			openai.WithOrgID(viper.GetString("openai.org_id")),
-			openai.WithProxyURL(viper.GetString("openai.proxy")),
-			openai.WithSocksURL(viper.GetString("openai.socks")),
-			openai.WithBaseURL(viper.GetString("openai.base_url")),
-			openai.WithTimeout(viper.GetDuration("openai.timeout")),
-			openai.WithMaxTokens(viper.GetInt("openai.max_tokens")),
-			openai.WithTemperature(float32(viper.GetFloat64("openai.temperature"))),
-			openai.WithProvider(viper.GetString("openai.provider")),
-			openai.WithSkipVerify(viper.GetBool("openai.skip_verify")),
-			openai.WithHeaders(viper.GetStringSlice("openai.headers")),
-			openai.WithApiVersion(viper.GetString("openai.api_version")),
-			openai.WithTopP(float32(viper.GetFloat64("openai.top_p"))),
-			openai.WithFrequencyPenalty(float32(viper.GetFloat64("openai.frequency_penalty"))),
-			openai.WithPresencePenalty(float32(viper.GetFloat64("openai.presence_penalty"))),
-		)
+		client, err := NewOpenAI()
 		if err != nil && !promptOnly {
 			return err
 		}
@@ -300,7 +287,7 @@ var commitCmd = &cobra.Command{
 		}
 		color.Cyan("Write the commit message to " + outputFile + " file")
 		// write commit message to git staging file
-		err = os.WriteFile(outputFile, []byte(commitMessage), 0o644)
+		err = os.WriteFile(outputFile, []byte(commitMessage), 0o600)
 		if err != nil {
 			return err
 		}

--- a/cmd/hepler.go
+++ b/cmd/hepler.go
@@ -15,7 +15,7 @@ import (
 func check() error {
 	// Check if the Git command is available on the system's PATH
 	if !util.IsCommandAvailable("git") {
-		return errors.New("Git command not found on your system's PATH. Please install Git and try again.")
+		return errors.New("git command not found on your system's PATH. Please install Git and try again")
 	}
 
 	// Update Viper configuration values based on the CLI flags

--- a/cmd/openai.go
+++ b/cmd/openai.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"github.com/appleboy/CodeGPT/openai"
+
+	"github.com/spf13/viper"
+)
+
+func NewOpenAI() (*openai.Client, error) {
+	return openai.New(
+		openai.WithToken(viper.GetString("openai.api_key")),
+		openai.WithModel(viper.GetString("openai.model")),
+		openai.WithOrgID(viper.GetString("openai.org_id")),
+		openai.WithProxyURL(viper.GetString("openai.proxy")),
+		openai.WithSocksURL(viper.GetString("openai.socks")),
+		openai.WithBaseURL(viper.GetString("openai.base_url")),
+		openai.WithTimeout(viper.GetDuration("openai.timeout")),
+		openai.WithMaxTokens(viper.GetInt("openai.max_tokens")),
+		openai.WithTemperature(float32(viper.GetFloat64("openai.temperature"))),
+		openai.WithProvider(viper.GetString("openai.provider")),
+		openai.WithSkipVerify(viper.GetBool("openai.skip_verify")),
+		openai.WithHeaders(viper.GetStringSlice("openai.headers")),
+		openai.WithApiVersion(viper.GetString("openai.api_version")),
+		openai.WithTopP(float32(viper.GetFloat64("openai.top_p"))),
+		openai.WithFrequencyPenalty(float32(viper.GetFloat64("openai.frequency_penalty"))),
+		openai.WithPresencePenalty(float32(viper.GetFloat64("openai.presence_penalty"))),
+	)
+}

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/appleboy/CodeGPT/git"
-	"github.com/appleboy/CodeGPT/openai"
 	"github.com/appleboy/CodeGPT/prompt"
 	"github.com/appleboy/CodeGPT/util"
 
@@ -19,12 +18,15 @@ import (
 var maxTokens int
 
 func init() {
-	reviewCmd.Flags().IntVar(&diffUnified, "diff_unified", 3, "generate diffs with <n> lines of context, default is 3")
-	reviewCmd.Flags().IntVar(&maxTokens, "max_tokens", 300, "the maximum number of tokens to generate in the chat completion.")
+	reviewCmd.Flags().IntVar(&diffUnified, "diff_unified", 3,
+		"generate diffs with <n> lines of context, default is 3")
+	reviewCmd.Flags().IntVar(&maxTokens, "max_tokens", 300,
+		"the maximum number of tokens to generate in the chat completion.")
 	reviewCmd.Flags().StringVar(&commitModel, "model", "gpt-3.5-turbo", "select openai model")
 	reviewCmd.Flags().StringVar(&commitLang, "lang", "en", "summarizing language uses English by default")
 	reviewCmd.Flags().StringSliceVar(&excludeList, "exclude_list", []string{}, "exclude file from git diff command")
-	reviewCmd.Flags().BoolVar(&commitAmend, "amend", false, "replace the tip of the current branch by creating a new commit.")
+	reviewCmd.Flags().BoolVar(&commitAmend, "amend", false,
+		"replace the tip of the current branch by creating a new commit.")
 }
 
 var reviewCmd = &cobra.Command{
@@ -53,24 +55,7 @@ var reviewCmd = &cobra.Command{
 
 		currentModel := viper.GetString("openai.model")
 		color.Green("Code review your changes using " + currentModel + " model")
-		client, err := openai.New(
-			openai.WithToken(viper.GetString("openai.api_key")),
-			openai.WithModel(viper.GetString("openai.model")),
-			openai.WithOrgID(viper.GetString("openai.org_id")),
-			openai.WithProxyURL(viper.GetString("openai.proxy")),
-			openai.WithSocksURL(viper.GetString("openai.socks")),
-			openai.WithBaseURL(viper.GetString("openai.base_url")),
-			openai.WithTimeout(viper.GetDuration("openai.timeout")),
-			openai.WithMaxTokens(viper.GetInt("openai.max_tokens")),
-			openai.WithTemperature(float32(viper.GetFloat64("openai.temperature"))),
-			openai.WithProvider(viper.GetString("openai.provider")),
-			openai.WithSkipVerify(viper.GetBool("openai.skip_verify")),
-			openai.WithHeaders(viper.GetStringSlice("openai.headers")),
-			openai.WithApiVersion(viper.GetString("openai.api_version")),
-			openai.WithTopP(float32(viper.GetFloat64("openai.top_p"))),
-			openai.WithFrequencyPenalty(float32(viper.GetFloat64("openai.frequency_penalty"))),
-			openai.WithPresencePenalty(float32(viper.GetFloat64("openai.presence_penalty"))),
-		)
+		client, err := NewOpenAI()
 		if err != nil {
 			return err
 		}
@@ -110,7 +95,8 @@ var reviewCmd = &cobra.Command{
 			}
 
 			// translate a git commit message
-			color.Cyan("We are trying to translate code review to " + prompt.GetLanguage(viper.GetString("output.lang")) + " language")
+			color.Cyan("we are trying to translate code review to " +
+				prompt.GetLanguage(viper.GetString("output.lang")) + " language")
 			resp, err := client.Completion(cmd.Context(), out)
 			if err != nil {
 				return err

--- a/git/git.go
+++ b/git/git.go
@@ -170,7 +170,7 @@ func (c *Command) InstallHook() error {
 
 	target := path.Join(strings.TrimSpace(string(hookPath)), HookPrepareCommitMessageTemplate)
 	if file.IsFile(target) {
-		return errors.New("hook file prepare-commit-msg exist.")
+		return errors.New("hook file prepare-commit-msg exist")
 	}
 
 	content, err := util.GetTemplateByBytes(HookPrepareCommitMessageTemplate, nil)
@@ -178,7 +178,7 @@ func (c *Command) InstallHook() error {
 		return err
 	}
 
-	return os.WriteFile(target, content, 0o755)
+	return os.WriteFile(target, content, 0o600)
 }
 
 func (c *Command) UninstallHook() error {
@@ -189,7 +189,7 @@ func (c *Command) UninstallHook() error {
 
 	target := path.Join(strings.TrimSpace(string(hookPath)), HookPrepareCommitMessageTemplate)
 	if !file.IsFile(target) {
-		return errors.New("hook file prepare-commit-msg is not exist.")
+		return errors.New("hook file prepare-commit-msg is not exist")
 	}
 	return os.Remove(target)
 }


### PR DESCRIPTION
- Add a new `.golangci.yml` configuration file with a list of linters and a 3-minute timeout setting
- Refactor `commit.go` to improve readability by breaking long lines of flag definitions
- Replace the OpenAI client initialization in `commit.go` with a call to a new function `NewOpenAI`
- Change file permission in `commit.go` from `644` to `600` when writing the `outputFile`
- Fix a typo in an error message in `hepler.go` (should be `helper.go`)
- Create a new `openai.go` file to handle OpenAI client initialization
- Remove OpenAI client initialization from `review.go` and replace it with a call to `NewOpenAI`
- Refactor `review.go` to improve readability by breaking long lines of flag definitions
- Update error messages in `git.go` to remove periods at the end
- Change file permission in `git.go` from `755` to `600` when writing the hook file