### PR TITLE
style: refactor codebase and update linting rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ linters:
     - errcheck
     - exportloopref
     - exhaustive
-    - gochecknoinits
     - goconst
     - gocritic
     - gocyclo
@@ -20,7 +19,6 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - lll
     - misspell
     - nakedret
     - noctx

--- a/cmd/openai.go
+++ b/cmd/openai.go
@@ -20,7 +20,7 @@ func NewOpenAI() (*openai.Client, error) {
 		openai.WithProvider(viper.GetString("openai.provider")),
 		openai.WithSkipVerify(viper.GetBool("openai.skip_verify")),
 		openai.WithHeaders(viper.GetStringSlice("openai.headers")),
-		openai.WithApiVersion(viper.GetString("openai.api_version")),
+		openai.WithAPIVersion(viper.GetString("openai.api_version")),
 		openai.WithTopP(float32(viper.GetFloat64("openai.top_p"))),
 		openai.WithFrequencyPenalty(float32(viper.GetFloat64("openai.frequency_penalty"))),
 		openai.WithPresencePenalty(float32(viper.GetFloat64("openai.presence_penalty"))),

--- a/git/hook.go
+++ b/git/hook.go
@@ -15,7 +15,7 @@ const (
 	CommitMessageTemplate            = "commit-msg.tmpl"
 )
 
-func init() {
+func init() { //nolint:gochecknoinits
 	if err := util.LoadTemplates(files); err != nil {
 		log.Fatal(err)
 	}

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -152,7 +152,7 @@ func New(opts ...Option) (*Client, error) {
 	// Create a new HTTP transport.
 	tr := &http.Transport{}
 	if cfg.skipVerify {
-		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
 	}
 
 	// Create a new HTTP client with the specified timeout and proxy, if any.

--- a/openai/options.go
+++ b/openai/options.go
@@ -160,8 +160,8 @@ func WithHeaders(headers []string) Option {
 	})
 }
 
-// WithApiVersion returns a new Option that sets the apiVersion for OpenAI Model.
-func WithApiVersion(apiVersion string) Option {
+// WithAPIVersion returns a new Option that sets the apiVersion for OpenAI Model.
+func WithAPIVersion(apiVersion string) Option {
 	return optionFunc(func(c *config) {
 		c.apiVersion = apiVersion
 	})

--- a/prompt/prompt.go
+++ b/prompt/prompt.go
@@ -23,7 +23,7 @@ const (
 )
 
 // Initializes the prompt package by loading the templates from the embedded file system.
-func init() {
+func init() { //nolint:gochecknoinits
 	if err := util.LoadTemplates(templatesFS); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
- Remove linters `gochecknoinits` and `lll` from the `.golangci.yml` configuration
- Correct the case of the `WithApiVersion` function to `WithAPIVersion` in `openai.go` and `options.go`
- Suppress the `gochecknoinits` lint warning in `init` functions in `hook.go` and `prompt.go`
- Suppress the `gosec` lint warning for `InsecureSkipVerify` in `openai.go`