### PR TITLE
refactor: provider handling and core interfaces

### DIFF
--- a/core/openai.go
+++ b/core/openai.go
@@ -1,0 +1,23 @@
+package core
+
+import (
+	"context"
+)
+
+type Usage struct {
+	PromptTokens     int
+	CompletionTokens int
+	TotalTokens      int
+}
+
+type Response struct {
+	Content string
+	Usage   Usage
+}
+
+type Generative interface {
+	// CreateCompletion is an API call to create a completion.
+	Completion(ctx context.Context, content string) (resp *Response, err error)
+	// GetSummaryPrefix is an API call to get a summary prefix using function call.
+	GetSummaryPrefix(ctx context.Context, content string) (resp *Response, err error)
+}

--- a/core/platform.go
+++ b/core/platform.go
@@ -1,0 +1,23 @@
+package core
+
+type Platform string
+
+const (
+	OpenAI Platform = "openai"
+	Azure  Platform = "azure"
+	Gemini Platform = "gemini"
+)
+
+// String returns the string representation of the Platform.
+func (p Platform) String() string {
+	return string(p)
+}
+
+// IsValid returns true if the Platform is valid.
+func (p Platform) IsValid() bool {
+	switch p {
+	case OpenAI, Azure, Gemini:
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
- Add error handling for invalid provider in `commit.go`
- Replace `NewOpenAI` initialization with a switch case for different providers
- Simplify the summary prefix retrieval logic in `commit.go`
- Create a new `core/openai.go` file defining `Usage`, `Response`, and `Generative` interface
- Create a new `core/platform.go` file defining `Platform` type and its methods
- Implement `Completion` and `GetSummaryPrefix` methods in `openai.go` for the `core.Generative` interface
- Refactor `Completion` method to `completion` in `openai.go`