### PR TITLE
refactor: use core.Platform instead of Provider type

### DIFF
--- a/cmd/openai.go
+++ b/cmd/openai.go
@@ -20,7 +20,7 @@ func NewOpenAI() (*openai.Client, error) {
 		openai.WithTimeout(viper.GetDuration("openai.timeout")),
 		openai.WithMaxTokens(viper.GetInt("openai.max_tokens")),
 		openai.WithTemperature(float32(viper.GetFloat64("openai.temperature"))),
-		openai.WithProvider(viper.GetString("openai.provider")),
+		openai.WithProvider(core.Platform(viper.GetString("openai.provider"))),
 		openai.WithSkipVerify(viper.GetBool("openai.skip_verify")),
 		openai.WithHeaders(viper.GetStringSlice("openai.headers")),
 		openai.WithAPIVersion(viper.GetString("openai.api_version")),

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -226,7 +226,7 @@ func New(opts ...Option) (*Client, error) {
 	}
 
 	// Set the OpenAI client to use the default configuration with Azure-specific options, if the provider is Azure.
-	if cfg.provider == AZURE {
+	if cfg.provider == core.Azure {
 		defaultAzureConfig := openai.DefaultAzureConfig(cfg.token, cfg.baseURL)
 		defaultAzureConfig.AzureModelMapperFunc = func(model string) string {
 			return cfg.model

--- a/openai/options.go
+++ b/openai/options.go
@@ -4,32 +4,14 @@ import (
 	"errors"
 	"time"
 
+	"github.com/appleboy/CodeGPT/core"
+
 	"github.com/sashabaranov/go-openai"
 )
 
 var (
 	errorsMissingToken = errors.New("please set OPENAI_API_KEY environment variable")
 	errorsMissingModel = errors.New("missing model")
-)
-
-type Provider string
-
-func (p Provider) String() string {
-	return string(p)
-}
-
-func (p Provider) IsValid() bool {
-	switch p {
-	case OPENAI, AZURE:
-		return true
-	default:
-		return false
-	}
-}
-
-var (
-	OPENAI Provider = "openai"
-	AZURE  Provider = "azure"
 )
 
 const (
@@ -135,14 +117,9 @@ func WithTemperature(val float32) Option {
 }
 
 // WithProvider returns a new Option that sets the provider for the client configuration.
-func WithProvider(val string) Option {
-	provider := Provider(val)
-	if !provider.IsValid() {
-		provider = OPENAI
-	}
-
+func WithProvider(val core.Platform) Option {
 	return optionFunc(func(c *config) {
-		c.provider = provider
+		c.provider = val
 	})
 }
 
@@ -204,7 +181,7 @@ type config struct {
 	presencePenalty  float32
 	frequencyPenalty float32
 
-	provider   Provider
+	provider   core.Platform
 	skipVerify bool
 	headers    []string
 	apiVersion string
@@ -232,7 +209,7 @@ func newConfig(opts ...Option) *config {
 		model:       defaultModel,
 		maxTokens:   defaultMaxTokens,
 		temperature: defaultTemperature,
-		provider:    OPENAI,
+		provider:    core.OpenAI,
 		topP:        defaultTopP,
 	}
 

--- a/openai/options_test.go
+++ b/openai/options_test.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"testing"
 
+	"github.com/appleboy/CodeGPT/core"
 	openai "github.com/sashabaranov/go-openai"
 )
 
@@ -17,7 +18,7 @@ func Test_config_valid(t *testing.T) {
 			cfg: newConfig(
 				WithToken("test"),
 				WithModel(openai.GPT3Dot5Turbo),
-				WithProvider(OPENAI.String()),
+				WithProvider(core.OpenAI),
 			),
 			wantErr: nil,
 		},
@@ -31,7 +32,7 @@ func Test_config_valid(t *testing.T) {
 			cfg: newConfig(
 				WithToken("test"),
 				WithModel(""),
-				WithProvider(OPENAI.String()),
+				WithProvider(core.OpenAI),
 			),
 			wantErr: errorsMissingModel,
 		},
@@ -40,7 +41,7 @@ func Test_config_valid(t *testing.T) {
 			cfg: newConfig(
 				WithToken("test"),
 				WithModel(""),
-				WithProvider(AZURE.String()),
+				WithProvider(core.Azure),
 			),
 			wantErr: errorsMissingModel,
 		},


### PR DESCRIPTION
- Update `WithProvider` to use `core.Platform` instead of a string
- Replace `Provider` type with `core.Platform`
- Remove `Provider` type and its associated methods
- Update test cases to use `core.Platform` constants