### PR TITLE
feat: ensure git commit --amend works with prepare-commit-msg hook

### DIFF
--- a/git/templates/prepare-commit-msg
+++ b/git/templates/prepare-commit-msg
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-if [[ "$2" != "message" ]]; then
+if [[ "$2" != "message" && "$2" != "commit" ]]; then
     codegpt commit --file $1 --preview
 fi


### PR DESCRIPTION
When the generated message quality is not good, I use `codegpt commit --amend` to regenerate the message. 

**But there are still small parts that need to be modified manually.**

Using `git commit --amend` in the current version will cause the following error:
```
Error: please add your staged changes using git add <files...>
```

So I modified the `git/templates/prepare-commit-msg` file, so that `codegpt` is not executed when `git commit --amend` is used.

See the Git Hooks [documentation](https://git-scm.com/docs/githooks#_prepare_commit_msg)
> The second is the source of the commit message, and can be: message (if a -m or -F option was given); template (if a -t option was given or the configuration option commit.template is set); merge (if the commit is a merge or a .git/MERGE_MSG file exists); squash (if a .git/SQUASH_MSG file exists); or commit, followed by a commit object name (if a -c, -C or --amend option was given).