### PR TITLE
feat: introduce hook management commands for git hooks

### DIFF
--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -1,39 +1,51 @@
 package cmd
 
 import (
-	"errors"
-
 	"github.com/appleboy/CodeGPT/git"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
+func init() {
+	hookCmd.AddCommand(hookInstallCmd)
+	hookCmd.AddCommand(hookUninstallCmd)
+}
+
+// hookCmd represents the command for installing/uninstalling the prepare-commit-msg hook.
 var hookCmd = &cobra.Command{
 	Use:   "hook",
 	Short: "install/uninstall git prepare-commit-msg hook",
-	Args:  cobra.MinimumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if args[0] != "install" && args[0] != "uninstall" {
-			return errors.New("only support install or uninstall command")
-		}
+}
 
+// hookInstallCmd installs the prepare-commit-msg hook.
+var hookInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "install git prepare-commit-msg hook",
+	RunE: func(cmd *cobra.Command, args []string) error {
 		g := git.New()
 
-		switch args[0] {
-		case "install":
-			if err := g.InstallHook(); err != nil {
-				return err
-			}
-			color.Green("Install git hook: prepare-commit-msg successfully")
-			color.Green("You can see the hook file: .git/hooks/prepare-commit-msg")
-		case "uninstall":
-			if err := g.UninstallHook(); err != nil {
-				return err
-			}
-			color.Green("Remove git hook: prepare-commit-msg successfully")
+		if err := g.InstallHook(); err != nil {
+			return err
 		}
+		color.Green("Install git hook: prepare-commit-msg successfully")
+		color.Green("You can see the hook file: .git/hooks/prepare-commit-msg")
 
+		return nil
+	},
+}
+
+// hookUninstallCmd uninstalls the prepare-commit-msg hook.
+var hookUninstallCmd = &cobra.Command{
+	Use:   "uninstall",
+	Short: "uninstall git prepare-commit-msg hook",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		g := git.New()
+
+		if err := g.UninstallHook(); err != nil {
+			return err
+		}
+		color.Green("Remove git hook: prepare-commit-msg successfully")
 		return nil
 	},
 }


### PR DESCRIPTION
- Remove unused import of `errors`
- Add an `init` function to register `hookInstallCmd` and `hookUninstallCmd` commands
- Remove argument validation and error handling from `hookCmd`
- Introduce `hookInstallCmd` command for installing the prepare-commit-msg hook
- Introduce `hookUninstallCmd` command for uninstalling the prepare-commit-msg hook

fix https://github.com/appleboy/CodeGPT/issues/138