### PR TITLE
feat: implement commit message editing with bubbletea UI

### DIFF
--- a/cmd/textarea.go
+++ b/cmd/textarea.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textarea"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type errMsg error
+
+type model struct {
+	textarea textarea.Model
+	err      error
+}
+
+func initialPrompt(value string) model {
+	ti := textarea.New()
+	ti.InsertString(value)
+	ti.SetWidth(80)
+	ti.SetHeight(len(strings.Split(value, "\n")))
+	ti.Focus()
+
+	return model{
+		textarea: ti,
+		err:      nil,
+	}
+}
+
+func (m model) Init() tea.Cmd {
+	return textarea.Blink
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmds []tea.Cmd
+	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.Type { //nolint:exhaustive
+		case tea.KeyEsc:
+			if m.textarea.Focused() {
+				m.textarea.Blur()
+			}
+		case tea.KeyCtrlC:
+			return m, tea.Quit
+		default:
+			if !m.textarea.Focused() {
+				cmd = m.textarea.Focus()
+				cmds = append(cmds, cmd)
+			}
+		}
+
+	// We handle errors just like any other message
+	case errMsg:
+		m.err = msg
+		return m, nil
+	}
+
+	m.textarea, cmd = m.textarea.Update(msg)
+	cmds = append(cmds, cmd)
+	return m, tea.Batch(cmds...)
+}
+
+func (m model) View() string {
+	return fmt.Sprintf(
+		"Please confirm the following commit message.\n\n%s\n\n%s",
+		m.textarea.View(),
+		"(ctrl+c to continue.)",
+	) + "\n\n"
+}


### PR DESCRIPTION
- Add `tea` import from `github.com/charmbracelet/bubbletea`
- Trim commit message before displaying it
- Change confirmation prompt default to `Yes`
- Add prompt to change commit message with default `No`
- Add logic to handle commit message change using `bubbletea` program
- Create new file `textarea.go` for handling commit message input
- Implement `model` struct and functions for `textarea` interaction
- Add `View` function to display commit message confirmation prompt

fixed https://github.com/appleboy/CodeGPT/issues/146