### PR TITLE
feat: add noConfirm flag to streamline commit process

### DIFF
--- a/git/templates/prepare-commit-msg
+++ b/git/templates/prepare-commit-msg
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [[ "$2" != "message" && "$2" != "commit" ]]; then
-    codegpt commit --file $1 --preview
+  codegpt commit --file $1 --preview --no_confirm
 fi


### PR DESCRIPTION
- Add a `noConfirm` flag to skip the confirmation prompt
- Modify `commitCmd` to check for `noConfirm` flag in preview mode
- Update `prepare-commit-msg` template to include `--no_confirm` flag in `codegpt commit` command

fix #188 