### PR TITLE
fix(gemini): refactor maxTokens type to int32 across the codebase

### DIFF
--- a/cmd/openai.go
+++ b/cmd/openai.go
@@ -36,7 +36,7 @@ func NewGemini() (*gemini.Client, error) {
 	return gemini.New(
 		gemini.WithToken(viper.GetString("openai.api_key")),
 		gemini.WithModel(viper.GetString("openai.model")),
-		gemini.WithMaxTokens(viper.GetInt("openai.max_tokens")),
+		gemini.WithMaxTokens(viper.GetInt32("openai.max_tokens")),
 		gemini.WithTemperature(float32(viper.GetFloat64("openai.temperature"))),
 		gemini.WithTopP(float32(viper.GetFloat64("openai.top_p"))),
 	)

--- a/gemini/gemini.go
+++ b/gemini/gemini.go
@@ -15,7 +15,7 @@ import (
 type Client struct {
 	client      *genai.GenerativeModel
 	model       string
-	maxTokens   int
+	maxTokens   int32
 	temperature float32
 	topP        float32
 	debug       bool
@@ -106,7 +106,7 @@ func New(opts ...Option) (c *Client, err error) {
 	}
 
 	engine.client = client.GenerativeModel(engine.model)
-	engine.client.MaxOutputTokens = util.Int32Ptr(int32(engine.maxTokens))
+	engine.client.MaxOutputTokens = util.Int32Ptr(engine.maxTokens)
 	engine.client.Temperature = util.Float32Ptr(engine.temperature)
 	engine.client.TopP = util.Float32Ptr(engine.topP)
 

--- a/gemini/options.go
+++ b/gemini/options.go
@@ -50,7 +50,7 @@ func WithModel(val string) Option {
 // WithMaxTokens returns a new Option that sets the max tokens for the client configuration.
 // The maximum number of tokens to generate in the chat completion.
 // The total length of input tokens and generated tokens is limited by the model's context length.
-func WithMaxTokens(val int) Option {
+func WithMaxTokens(val int32) Option {
 	if val <= 0 {
 		val = defaultMaxTokens
 	}
@@ -83,7 +83,7 @@ func WithTopP(val float32) Option {
 type config struct {
 	token       string
 	model       string
-	maxTokens   int
+	maxTokens   int32
 	temperature float32
 	topP        float32
 }


### PR DESCRIPTION
- Change the type of `maxTokens` from `int` to `int32` in multiple files
- Update the function `WithMaxTokens` to accept `int32` instead of `int`
- Adjust the usage of `maxTokens` in the `New` function to match the new type