### PR TITLE
chore: update shebang for prepare-commit-msg script

### DIFF
--- a/git/templates/prepare-commit-msg
+++ b/git/templates/prepare-commit-msg
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 if [[ "$2" != "message" && "$2" != "commit" ]]; then
   codegpt commit --file $1 --preview --no_confirm


### PR DESCRIPTION
Hello, and thank you for this amazing product.

This pull request updates the shebang in a shell script that works with git hooks.

**Reason:**
POSIX sh does not support the `[[ ]]` syntax. 
The `[[ ]]` syntax works in bash and similar shells, but it is not supported by sh.
If the shell script is intended to work with bash, I recommend using the shebang `#!/usr/bin/env bash`.

Thank you for your consideration.