### PR TITLE
docs: improve grammar, clarity, and consistency in documentation

### DIFF
--- a/prompt/templates/code_review_file_diff.tmpl
+++ b/prompt/templates/code_review_file_diff.tmpl
@@ -1,5 +1,5 @@
-Bellow is the code patch, please help me do a brief code review if any bug risk, security vulnerabilities and improvement suggestion are welcome
+Below is the code patch. Please help me do a brief code review. Any bug risks, security vulnerabilities, and improvement suggestions are welcome.
 
-THE Code Patch TO BE Reviewed:
+THE CODE PATCH TO BE REVIEWED:
 
 {{ .file_diffs }}

--- a/prompt/templates/conventional_commit.tmpl
+++ b/prompt/templates/conventional_commit.tmpl
@@ -1,19 +1,19 @@
 You are an expert programmer, and you are trying to summarize a code change.
 You went over every file that was changed in it.
-For some of these files changes where too big and were omitted in the files diff summary.
+For some of these files, changes were too big and were omitted in the file's diff summary.
 Determine the best label for the commit.
 
 Here are the labels you can choose from:
 
 - build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-- chore: Updating libraries, copyrights or other repo setting, includes updating dependencies.
+- chore: Updating libraries, copyrights, or other repo settings, includes updating dependencies.
 - ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, GitHub Actions)
-- docs: Non-code changes, such as fixing typos or adding new documentation (example scopes: Markdown file)
-- feat: a commit of the type feat introduces a new feature to the codebase
+- docs: Non-code changes, such as fixing typos or adding new documentation (example scopes: Markdown files)
+- feat: A commit of the type feat introduces a new feature to the codebase
 - fix: A commit of the type fix patches a bug in your codebase
 - perf: A code change that improves performance
 - refactor: A code change that neither fixes a bug nor adds a feature
-- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
 - test: Adding missing tests or correcting existing tests
 
 

--- a/prompt/templates/summarize_file_diff.tmpl
+++ b/prompt/templates/summarize_file_diff.tmpl
@@ -10,7 +10,7 @@ index aadf691..bfef603 100644
 This means that `lib/index.js` was modified in this commit. Note that this is only an example.
 Then there is a specifier of the lines that were modified.
 A line starting with `+` means it was added.
-A line that starting with `-` means that line was deleted.
+A line starting with `-` means that line was deleted.
 A line that starts with neither `+` nor `-` is code given for context and better understanding.
 It is not part of the diff.
 After the git diff of the first file, there will be an empty line, and then the git diff of the next file.
@@ -32,7 +32,7 @@ EXAMPLE SUMMARY COMMENTS:
 - Lower numeric tolerance for test files
 - Add 2 tests for the inclusive string split function
 
-Most commits will have less comments than this examples list.
+Most commits will have fewer comments than this example list.
 The last comment does not include the file names,
 because there were more than two relevant files in the hypothetical commit.
 Do not include parts of the example in your summary.

--- a/prompt/templates/summarize_title.tmpl
+++ b/prompt/templates/summarize_title.tmpl
@@ -1,9 +1,9 @@
 You are an expert programmer, and you are trying to title a pull request.
-You went over every file that was changed in it.
-For some of these files changes were too big and were omitted in the files diff summary.
+You reviewed every file that was changed in it.
+For some of these files, changes were too extensive and were omitted in the file's diff summary.
 Please summarize the pull request into a single specific theme.
 Write your response using the imperative tense following the kernel git commit style guide.
-Write a high level title.
+Write a high-level title.
 Do not repeat the commit summaries or the file summaries.
 Do not list individual changes in the title.
 
@@ -19,5 +19,5 @@ THE FILE SUMMARIES:
 
 {{ .summary_points }}
 
-Remember to write only one line, no more than 50 characters.
+Remember to write only one line, no more than 60 characters.
 THE PULL REQUEST TITLE:

--- a/prompt/templates/translation.tmpl
+++ b/prompt/templates/translation.tmpl
@@ -1,5 +1,5 @@
 You are a professional programmer and translator, and you are trying to translate a git commit message.
-You want to ensure that the translation is high level and in line with the programmer's consensus, taking care to keep the formatting intact.
+You want to ensure that the translation is high-level and in line with the programmer's consensus, taking care to keep the formatting intact.
 
 Now, translate the following message into {{ .output_language }}.
 


### PR DESCRIPTION
- Correct typo "Bellow" to "Below" and improve sentence structure for clarity.
- Capitalize "CODE PATCH TO BE REVIEWED" for consistency.
- Fix grammatical errors and improve clarity in the conventional commit template.
- Correct "less" to "fewer" in the example summary comments.
- Fix grammatical error in the summarize file diff template.
- Change "high level" to "high-level" for consistency.
- Update character limit reminder from 50 to 60 characters.
- Ensure translation instructions emphasize high-level translation and formatting integrity.

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>