### PR TITLE
feat: add support for Anthropic provider integration

### DIFF
--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/appleboy/CodeGPT/core"
+	"github.com/appleboy/CodeGPT/provider/anthropic"
 	"github.com/appleboy/CodeGPT/provider/gemini"
 	"github.com/appleboy/CodeGPT/provider/openai"
 
@@ -44,6 +45,26 @@ func NewGemini(ctx context.Context) (*gemini.Client, error) {
 	)
 }
 
+// NewAnthropic creates a new instance of the anthropic.Client using configuration
+// values retrieved from Viper. The configuration values include the API key,
+// model, maximum tokens, temperature, and top_p.
+//
+// Parameters:
+//   - ctx: The context for the client.
+//
+// Returns:
+//   - A pointer to an anthropic.Client instance.
+//   - An error if the client could not be created.
+func NewAnthropic(ctx context.Context) (*anthropic.Client, error) {
+	return anthropic.New(
+		anthropic.WithAPIKey(viper.GetString("openai.api_key")),
+		anthropic.WithModel(viper.GetString("openai.model")),
+		anthropic.WithMaxTokens(viper.GetInt("openai.max_tokens")),
+		anthropic.WithTemperature(float32(viper.GetFloat64("openai.temperature"))),
+		anthropic.WithTopP(float32(viper.GetFloat64("openai.top_p"))),
+	)
+}
+
 // GetClient returns the generative client based on the platform
 func GetClient(ctx context.Context, p core.Platform) (core.Generative, error) {
 	switch p {
@@ -51,6 +72,8 @@ func GetClient(ctx context.Context, p core.Platform) (core.Generative, error) {
 		return NewGemini(ctx)
 	case core.OpenAI, core.Azure:
 		return NewOpenAI()
+	case core.Anthropic:
+		return NewAnthropic(ctx)
 	}
 	return nil, errors.New("invalid provider")
 }

--- a/core/platform.go
+++ b/core/platform.go
@@ -3,9 +3,10 @@ package core
 type Platform string
 
 const (
-	OpenAI Platform = "openai"
-	Azure  Platform = "azure"
-	Gemini Platform = "gemini"
+	OpenAI    Platform = "openai"
+	Azure     Platform = "azure"
+	Gemini    Platform = "gemini"
+	Anthropic Platform = "anthropic"
 )
 
 // String returns the string representation of the Platform.
@@ -16,7 +17,7 @@ func (p Platform) String() string {
 // IsValid returns true if the Platform is valid.
 func (p Platform) IsValid() bool {
 	switch p {
-	case OpenAI, Azure, Gemini:
+	case OpenAI, Azure, Gemini, Anthropic:
 		return true
 	}
 	return false

--- a/provider/anthropic/options.go
+++ b/provider/anthropic/options.go
@@ -43,9 +43,9 @@ func WithAPIKey(val string) Option {
 }
 
 // WithModel is a function that returns an Option, which sets the model field of the config struct.
-func WithModel(val anthropic.Model) Option {
+func WithModel(val string) Option {
 	return optionFunc(func(c *config) {
-		c.model = val
+		c.model = anthropic.Model(val)
 	})
 }
 


### PR DESCRIPTION
- Rename `cmd/openai.go` to `cmd/provider.go`
- Add support for the Anthropic provider
- Add `NewAnthropic` function to create a new instance of `anthropic.Client`
- Update `GetClient` function to include the Anthropic platform
- Define `Anthropic` as a new platform constant
- Update `IsValid` function to include the Anthropic platform
- Change `WithModel` function parameter type from `anthropic.Model` to `string`

ref: #134 