### PR TITLE
feat(anthropic): tool handling and improve summary prefix logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ dist
 **/.DS_Store
 bin
 release
+.codegpt.yaml

--- a/provider/anthropic/func.go
+++ b/provider/anthropic/func.go
@@ -5,6 +5,22 @@ import (
 	"github.com/sashabaranov/go-openai/jsonschema"
 )
 
+// tool represents a structure with a single field Prefix.
+// Prefix is a string that is serialized to JSON with the key "prefix".
+type tool struct {
+	Prefix string `json:"prefix"`
+}
+
+// tools is a slice of ToolDefinition that contains the definition for various tools.
+// Each ToolDefinition includes the following fields:
+// - Name: The name of the tool.
+// - Description: A brief description of what the tool does.
+// - InputSchema: The schema for the input that the tool expects, defined using jsonschema.Definition.
+//   - Type: The type of the input, which is an object.
+//   - Properties: A map of property names to their definitions. In this case, it includes:
+//   - "prefix": A string that must be one of the specified values ("build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test").
+//     This property also has a description indicating that it is the prefix to use for the summary.
+//   - Required: A list of required properties, which includes "prefix".
 var tools = []anthropic.ToolDefinition{
 	{
 		Name:        "get_summary_prefix",
@@ -12,7 +28,7 @@ var tools = []anthropic.ToolDefinition{
 		InputSchema: jsonschema.Definition{
 			Type: jsonschema.Object,
 			Properties: map[string]jsonschema.Definition{
-				"unit": {
+				"prefix": {
 					Type: jsonschema.String,
 					Enum: []string{
 						"build", "chore", "ci",


### PR DESCRIPTION
- Add `.codegpt.yaml` to `.gitignore`
- Import `encoding/json` in `anthropic.go`
- Replace `MessageContentToolResult` with `MessageContentToolUse` in `GetSummaryPrefix` function
- Add JSON unmarshalling for `toolUse.Input` in `GetSummaryPrefix` function
- Change content assignment from `toolResult.Content[0].GetText()` to `result.Prefix` in `GetSummaryPrefix` function
- Define a new `tool` struct with a `Prefix` field in `func.go`
- Rename tool definition key from `unit` to `prefix` in `tools` slice

fix #134 