### PR TITLE
feat: add proxy and SOCKS5 support to HTTP Anthropic client

### DIFF
--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -62,6 +62,9 @@ func NewAnthropic(ctx context.Context) (*anthropic.Client, error) {
 		anthropic.WithMaxTokens(viper.GetInt("openai.max_tokens")),
 		anthropic.WithTemperature(float32(viper.GetFloat64("openai.temperature"))),
 		anthropic.WithTopP(float32(viper.GetFloat64("openai.top_p"))),
+		anthropic.WithProxyURL(viper.GetString("openai.proxy")),
+		anthropic.WithSocksURL(viper.GetString("openai.socks")),
+		anthropic.WithSkipVerify(viper.GetBool("openai.skip_verify")),
 	)
 }
 

--- a/provider/anthropic/options.go
+++ b/provider/anthropic/options.go
@@ -81,6 +81,27 @@ func WithTopP(val float32) Option {
 	})
 }
 
+// WithProxyURL is a function that returns an Option, which sets the proxyURL field of the config struct.
+func WithProxyURL(val string) Option {
+	return optionFunc(func(c *config) {
+		c.proxyURL = val
+	})
+}
+
+// WithSocksURL is a function that returns an Option, which sets the socksURL field of the config struct.
+func WithSocksURL(val string) Option {
+	return optionFunc(func(c *config) {
+		c.socksURL = val
+	})
+}
+
+// WithSkipVerify returns a new Option that sets the skipVerify for the client configuration.
+func WithSkipVerify(val bool) Option {
+	return optionFunc(func(c *config) {
+		c.skipVerify = val
+	})
+}
+
 // config is a struct that stores configuration options for the instrumentation.
 type config struct {
 	apiKey      string
@@ -88,6 +109,9 @@ type config struct {
 	maxTokens   int
 	temperature float32
 	topP        float32
+	proxyURL    string
+	socksURL    string
+	skipVerify  bool
 }
 
 // valid checks whether a config object is valid, returning an error if it is not.


### PR DESCRIPTION
- Add support for proxy URL, SOCKS URL, and skip verify options in the Anthropic client configuration
- Introduce `DefaultHeaderTransport` to add custom headers to HTTP requests
- Add new HTTP transport configuration for handling proxy and SOCKS URLs
- Update the Anthropic client initialization to use the new HTTP client with custom transport
- Add `WithProxyURL`, `WithSocksURL`, and `WithSkipVerify` options for configuring the Anthropic client