### PR TITLE
feat: refactor HTTP client to use new proxy package with timeout options

### DIFF
--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -65,6 +65,7 @@ func NewAnthropic(ctx context.Context) (*anthropic.Client, error) {
 		anthropic.WithProxyURL(viper.GetString("openai.proxy")),
 		anthropic.WithSocksURL(viper.GetString("openai.socks")),
 		anthropic.WithSkipVerify(viper.GetBool("openai.skip_verify")),
+		anthropic.WithTimeout(viper.GetDuration("openai.timeout")),
 	)
 }
 

--- a/provider/anthropic/options.go
+++ b/provider/anthropic/options.go
@@ -2,6 +2,7 @@ package anthropic
 
 import (
 	"errors"
+	"time"
 
 	"github.com/liushuangls/go-anthropic/v2"
 )
@@ -102,6 +103,15 @@ func WithSkipVerify(val bool) Option {
 	})
 }
 
+// WithTimeout returns a new Option that sets the timeout for the client configuration.
+// It takes a time.Duration value representing the timeout duration.
+// It returns an optionFunc that sets the timeout field of the configuration to the provided value.
+func WithTimeout(val time.Duration) Option {
+	return optionFunc(func(c *config) {
+		c.timeout = val
+	})
+}
+
 // config is a struct that stores configuration options for the instrumentation.
 type config struct {
 	apiKey      string
@@ -112,6 +122,7 @@ type config struct {
 	proxyURL    string
 	socksURL    string
 	skipVerify  bool
+	timeout     time.Duration
 }
 
 // valid checks whether a config object is valid, returning an error if it is not.

--- a/proxy/options.go
+++ b/proxy/options.go
@@ -1,0 +1,85 @@
+package proxy
+
+import (
+	"time"
+)
+
+// Option is an interface that specifies instrumentation configuration options.
+type Option interface {
+	apply(*config)
+}
+
+// optionFunc is a type of function that can be used to implement the Option interface.
+// It takes a pointer to a config struct and modifies it.
+type optionFunc func(*config)
+
+// Ensure that optionFunc satisfies the Option interface.
+var _ Option = (*optionFunc)(nil)
+
+// The apply method of optionFunc type is implemented here to modify the config struct based on the function passed.
+func (o optionFunc) apply(c *config) {
+	o(c)
+}
+
+// WithProxyURL is a function that returns an Option, which sets the proxyURL field of the config struct.
+func WithProxyURL(val string) Option {
+	return optionFunc(func(c *config) {
+		c.proxyURL = val
+	})
+}
+
+// WithSocksURL is a function that returns an Option, which sets the socksURL field of the config struct.
+func WithSocksURL(val string) Option {
+	return optionFunc(func(c *config) {
+		c.socksURL = val
+	})
+}
+
+// WithTimeout returns a new Option that sets the timeout for the client configuration.
+// It takes a time.Duration value representing the timeout duration.
+// It returns an optionFunc that sets the timeout field of the configuration to the provided value.
+func WithTimeout(val time.Duration) Option {
+	return optionFunc(func(c *config) {
+		c.timeout = val
+	})
+}
+
+// WithHeaders returns a new Option that sets the headers for the http client configuration.
+func WithHeaders(headers []string) Option {
+	return optionFunc(func(c *config) {
+		c.headers = headers
+	})
+}
+
+// WithSkipVerify returns a new Option that sets the insecure flag for the http client configuration.
+func WithSkipVerify(insecure bool) Option {
+	return optionFunc(func(c *config) {
+		c.insecure = insecure
+	})
+}
+
+// config is a struct that stores configuration options for the instrumentation.
+type config struct {
+	proxyURL string
+	socksURL string
+	timeout  time.Duration
+	insecure bool
+	headers  []string
+}
+
+// newConfig creates a new config object with default values, and applies the given options.
+func newConfig(opts ...Option) *config {
+	// Create a new config object with default values.
+	c := &config{
+		timeout:  30 * time.Second,
+		insecure: false,
+	}
+
+	// Apply each of the given options to the config object.
+	for _, opt := range opts {
+		opt.apply(c)
+	}
+
+	// Return the resulting config object.
+	return c
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1,0 +1,93 @@
+package proxy
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/proxy"
+)
+
+// convertHeaders creates a new http.Header from the given slice of headers.
+func convertHeaders(headers []string) http.Header {
+	h := make(http.Header)
+	for _, header := range headers {
+		// split header into key and value with = as delimiter
+		vals := strings.Split(header, "=")
+		if len(vals) != 2 {
+			continue
+		}
+		h.Add(vals[0], vals[1])
+	}
+	return h
+}
+
+// DefaultHeaderTransport is an http.RoundTripper that adds the given headers to
+type defaultHeaderTransport struct {
+	origin http.RoundTripper
+	header http.Header
+}
+
+// RoundTrip implements the http.RoundTripper interface.
+func (t *defaultHeaderTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	for key, values := range t.header {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+	return t.origin.RoundTrip(req)
+}
+
+// New creates a new HTTP client with the provided options.
+// It configures the client with optional TLS settings, proxy settings, and custom headers.
+//
+// Parameters:
+//
+//	opts - A variadic list of Option functions to configure the client.
+//
+// Returns:
+//
+//	*http.Client - A pointer to the configured HTTP client.
+//	error - An error if the proxy URL is invalid or if there is an issue connecting to the SOCKS5 proxy.
+func New(opts ...Option) (*http.Client, error) {
+	cfg := newConfig(opts...)
+	if cfg == nil {
+		return nil, fmt.Errorf("configuration is nil")
+	}
+
+	// Create a new HTTP transport with optional TLS configuration.
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: cfg.insecure}, //nolint:gosec
+	}
+
+	// Create a new HTTP client with the specified timeout.
+	httpClient := &http.Client{
+		Timeout:   cfg.timeout,
+		Transport: tr,
+	}
+
+	// Configure proxy settings if provided.
+	if cfg.proxyURL != "" {
+		proxyURL, err := url.Parse(cfg.proxyURL)
+		if err != nil {
+			return nil, fmt.Errorf("invalid proxy URL: %s", err)
+		}
+		tr.Proxy = http.ProxyURL(proxyURL)
+	} else if cfg.socksURL != "" {
+		dialer, err := proxy.SOCKS5("tcp", cfg.socksURL, nil, proxy.Direct)
+		if err != nil {
+			return nil, fmt.Errorf("can't connect to the SOCKS5 proxy: %s", err)
+		}
+		tr.DialContext = dialer.(proxy.ContextDialer).DialContext
+	}
+
+	// Set the HTTP client to use the default header transport with the specified headers.
+	httpClient.Transport = &defaultHeaderTransport{
+		origin: tr,
+		header: convertHeaders(cfg.headers),
+	}
+
+	return httpClient, nil
+}


### PR DESCRIPTION
- Add timeout configuration option to `NewAnthropic` function
- Remove unused imports and replace `golang.org/x/net/proxy` with `github.com/appleboy/CodeGPT/proxy` in `anthropic.go`
- Refactor HTTP client creation to use new proxy package in `anthropic.go`
- Add `WithTimeout` option function in `options.go`
- Add `timeout` field to `config` struct in `options.go`
- Remove unused imports and replace `golang.org/x/net/proxy` with `github.com/appleboy/CodeGPT/proxy` in `openai.go`
- Refactor HTTP client creation to use new proxy package in `openai.go`
- Create new `proxy` package with options and proxy configuration functions
- Add `defaultHeaderTransport` for setting default headers in HTTP client in `proxy.go`