### PR TITLE
refactor: textarea handling to use pointer-based implementation

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -316,6 +316,7 @@ var commitCmd = &cobra.Command{
 					return err
 				}
 				p.Wait()
+
 				commitMessage = m.textarea.Value()
 			}
 		}

--- a/cmd/textarea.go
+++ b/cmd/textarea.go
@@ -11,7 +11,7 @@ import (
 type errMsg error
 
 type model struct {
-	textarea textarea.Model
+	textarea *textarea.Model
 	err      error
 }
 
@@ -42,7 +42,7 @@ func initialPrompt(value string) model {
 	ti.Focus()
 
 	return model{
-		textarea: ti,
+		textarea: &ti,
 		err:      nil,
 	}
 }
@@ -77,7 +77,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	m.textarea, cmd = m.textarea.Update(msg)
+	*m.textarea, cmd = m.textarea.Update(msg)
 	cmds = append(cmds, cmd)
 	return m, tea.Batch(cmds...)
 }


### PR DESCRIPTION
- Add a blank line for better readability in `commit.go`
- Change `textarea` field to be a pointer in `textarea.go`
- Update `textarea` initialization to use a pointer in `textarea.go`
- Modify `textarea` update method to dereference the pointer in `textarea.go`