### PR TITLE
fix(azure): function call issues in deepseek-V3

### DIFF
--- a/provider/openai/openai.go
+++ b/provider/openai/openai.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/appleboy/CodeGPT/core"
 	"github.com/appleboy/CodeGPT/proxy"
@@ -64,7 +65,7 @@ func (c *Client) Completion(ctx context.Context, content string) (*core.Response
 func (c *Client) GetSummaryPrefix(ctx context.Context, content string) (*core.Response, error) {
 	var resp openai.ChatCompletionResponse
 	var err error
-	if checkOSeriesModels.MatchString(c.model) {
+	if checkOSeriesModels.MatchString(c.model) || strings.Contains(strings.ToLower(c.model), "deepseek") {
 		resp, err = c.CreateChatCompletion(ctx, content)
 		if err != nil || len(resp.Choices) != 1 {
 			return nil, err


### PR DESCRIPTION
## Issue
The function call of Deepseek-V3 is currently encountering problems, making it unable to work with tool calls. See [doc](https://api-docs.deepseek.com/guides/function_calling#notice).

## Solution
Fortunately, Deepseek-V3 operates correctly when using the ChatCompletion method, similar to OpenAI's models with the pattern `o\d(-(mini|preview))?`. This pull request aims to implement this solution.

## Proposed Changes
This pull request includes the necessary modifications to ensure that Deepseek-V3 can function properly with tool calls by utilizing the ChatCompletion method.

## Testing
The changes have been thoroughly tested to ensure compatibility and functionality with tool calls.

## Approval
Please review the proposed changes and provide your approval to proceed with the integration.
