### PR TITLE
feat: refactor prompt folder handling and update its configuration key

### DIFF
--- a/cmd/config_list.go
+++ b/cmd/config_list.go
@@ -36,6 +36,7 @@ var availableKeys = map[string]string{
 	"openai.top_p":             "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.",
 	"openai.frequency_penalty": "Number between 0.0 and 1.0 that penalizes new tokens based on their existing frequency in the text so far. Decreases the model's likelihood to repeat the same line verbatim.",
 	"openai.presence_penalty":  "Number between 0.0 and 1.0 that penalizes new tokens based on whether they appear in the text so far. Increases the model's likelihood to talk about new topics.",
+	"prompt.folder":            "prompt template folder",
 }
 
 // configListCmd represents the command to list the configuration values.

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -32,6 +32,7 @@ func init() {
 	configSetCmd.Flags().BoolP("skip_verify", "", false, availableKeys["openai.skip_verify"])
 	configSetCmd.Flags().StringP("headers", "", "", availableKeys["openai.headers"])
 	configSetCmd.Flags().StringP("api_version", "", "", availableKeys["openai.api_version"])
+	configSetCmd.Flags().StringP("prompt_folder", "", "", availableKeys["prompt.folder"])
 	_ = viper.BindPFlag("openai.base_url", configSetCmd.Flags().Lookup("base_url"))
 	_ = viper.BindPFlag("openai.org_id", configSetCmd.Flags().Lookup("org_id"))
 	_ = viper.BindPFlag("openai.api_key", configSetCmd.Flags().Lookup("api_key"))
@@ -50,6 +51,7 @@ func init() {
 	_ = viper.BindPFlag("openai.skip_verify", configSetCmd.Flags().Lookup("skip_verify"))
 	_ = viper.BindPFlag("openai.headers", configSetCmd.Flags().Lookup("headers"))
 	_ = viper.BindPFlag("openai.api_version", configSetCmd.Flags().Lookup("api_version"))
+	_ = viper.BindPFlag("prompt.folder", configSetCmd.Flags().Lookup("prompt_folder"))
 }
 
 // configSetCmd updates the config value.

--- a/cmd/hepler.go
+++ b/cmd/hepler.go
@@ -66,7 +66,7 @@ func check() error {
 	}
 
 	// load custom prompt
-	promptFolder := viper.GetString("prompt_folder")
+	promptFolder := viper.GetString("prompt.folder")
 	if promptFolder != "" {
 		if err := util.LoadTemplatesFromDir(promptFolder); err != nil {
 			return fmt.Errorf("failed to load custom prompt templates: %s", err)

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -39,12 +39,14 @@ var promptCmd = &cobra.Command{
 			return nil
 		}
 
-		confirm, err := confirmation.New("Do you want to load default prompt data, will overwrite your data", confirmation.No).RunPrompt()
+		folder := viper.GetString("prompt.folder")
+
+		color.Yellow("Prompt folder: %s", folder)
+		confirm, err := confirmation.New("Do you want to load the default prompt data? This will overwrite your existing data.", confirmation.No).RunPrompt()
 		if err != nil || !confirm {
 			return err
 		}
 
-		folder := viper.GetString("prompt_folder")
 		for _, key := range defaultPromptDataKeys {
 			if err := savePromptData(folder, key); err != nil {
 				return err


### PR DESCRIPTION
- Add detailed comments to the `initConfig` function to describe its steps and purpose
- Replace existing logic for handling the prompt folder with a switch-case structure
- Add `prompt.folder` configuration key to the list of available keys
- Add `prompt.folder` flag to `configSetCmd`
- Update the configuration key `prompt_folder` to `prompt.folder` in `helper.go`
- Enhance `prompt.go` to display the prompt folder path and improve confirmation prompt message

fix #226 