### PR TITLE
build: enhance build metadata and version reporting functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ GO ?= go
 EXECUTABLE := codegpt
 GOFILES := $(shell find . -type f -name "*.go")
 TAGS ?=
-LDFLAGS ?= -X 'github.com/appleboy/CodeGPT/version.Version=$(VERSION)' -X 'github.com/appleboy/CodeGPT/version.Commit=$(COMMIT)'
 
 ifneq ($(shell uname), Darwin)
 	EXTLDFLAGS = -extldflags "-static" $(null)
@@ -16,6 +15,14 @@ else
 	VERSION ?= $(shell git describe --tags --always || git rev-parse --short HEAD)
 endif
 COMMIT ?= $(shell git rev-parse --short HEAD)
+
+LDFLAGS ?= -X 'github.com/appleboy/CodeGPT/version.Version=$(VERSION)' \
+	-X 'github.com/appleboy/CodeGPT/version.BuildTime=$(shell date +%Y-%m-%dT%H:%M:%S)' \
+	-X 'github.com/appleboy/CodeGPT/version.GitCommit=$(shell git rev-parse HEAD)' \
+	-X 'github.com/appleboy/CodeGPT/version.GitBranch=$(shell git rev-parse --abbrev-ref HEAD)' \
+	-X 'github.com/appleboy/CodeGPT/version.GoVersion=$(shell $(GO) version | cut -d " " -f 3)' \
+	-X 'github.com/appleboy/CodeGPT/version.BuildOS=$(shell $(GO) env GOOS)' \
+	-X 'github.com/appleboy/CodeGPT/version.BuildArch=$(shell $(GO) env GOARCH)'
 
 ## build: build the codegpt binary
 build: $(EXECUTABLE)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,16 +1,96 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/appleboy/CodeGPT/version"
+
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
+/*
+VersionInfo holds all version-related information for the application.
+*/
+type VersionInfo struct {
+	Version   string `json:"version"`    // Application version
+	GitCommit string `json:"git_commit"` // Git commit SHA
+	BuildTime string `json:"build_time"` // Build timestamp
+	GoVersion string `json:"go_version"` // Go language version
+	BuildOS   string `json:"build_os"`   // Build operating system
+	BuildArch string `json:"build_arch"` // Build architecture
+	Platform  string `json:"platform"`   // Combined OS/Arch string
+}
+
+var outputFormat string
+
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Print the application version and commit information",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("version:", version.Version, "commit:", version.Commit)
+	Short: "Display version, commit, build time, and environment details",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		v := VersionInfo{
+			Version:   version.Version,
+			GitCommit: version.GitCommit,
+			BuildTime: version.BuildTime,
+			GoVersion: version.GoVersion,
+			BuildOS:   version.BuildOS,
+			BuildArch: version.BuildArch,
+			Platform:  fmt.Sprintf("%s/%s", version.BuildOS, version.BuildArch),
+		}
+		return printVersion(outputFormat, v)
 	},
+}
+
+func init() {
+	versionCmd.Flags().StringVarP(&outputFormat, "output", "o", "text", "Output format: text|json")
+}
+
+/*
+shortCommit returns the first 7 characters of a Git commit SHA (short SHA).
+*/
+func shortCommit(commit string) string {
+	if len(commit) > 7 {
+		return commit[:7]
+	}
+	return commit
+}
+
+/*
+printVersion prints version information in the specified format.
+
+format: "text" for colored CLI output, "json" for JSON output.
+v:      VersionInfo struct containing version data.
+*/
+func printVersion(format string, v VersionInfo) error {
+	// Use short SHA for Git commit
+	shortV := v
+	shortV.GitCommit = shortCommit(v.GitCommit)
+	switch format {
+	case "json":
+		// Output as pretty-printed JSON
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(shortV)
+	case "text":
+		fallthrough
+	default:
+		// Output as colored CLI text
+		blue := color.New(color.FgBlue, color.Bold)
+		// Each row contains a label and its value
+		rows := [][2]string{
+			{"Version:", shortV.Version},
+			{"Git Commit:", shortV.GitCommit},
+			{"Build Time:", shortV.BuildTime},
+			{"Go Version:", shortV.GoVersion},
+			{"OS/Arch:", fmt.Sprintf("%s/%s", shortV.BuildOS, shortV.BuildArch)},
+		}
+		// Print each row with colored label and default value color
+		for _, row := range rows {
+			blue.Print(row[0])
+			fmt.Printf(" %s\n", row[1])
+		}
+		return nil
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/appleboy/CodeGPT
 
-go 1.23.0
+go 1.24
 
 require (
 	github.com/appleboy/com v0.3.0

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,10 @@
 package version
 
 var (
-	Version string = ""
-	Commit  string = ""
+	Version   string
+	GitCommit string
+	BuildTime string
+	GoVersion string
+	BuildOS   string
+	BuildArch string
 )


### PR DESCRIPTION
- Expand embedded build-time variables to include Git commit, build time, Go version, operating system, and architecture
- Update build process to inject additional version and environment metadata
- Improve version command to output detailed build information, support both text and JSON formats, and add colored CLI output
- Update Go version requirement to 1.24 in go.mod