### PR TITLE
feat: add configurable Gemini provider with VertexAI and GeminiAPI support

### DIFF
--- a/cmd/config_list.go
+++ b/cmd/config_list.go
@@ -37,6 +37,10 @@ var availableKeys = map[string]string{
 	"openai.frequency_penalty": "Parameter to reduce repetition by penalizing tokens based on their frequency",
 	"openai.presence_penalty":  "Parameter to encourage topic diversity by penalizing previously used tokens",
 	"prompt.folder":            "Directory path for custom prompt templates",
+	"gemini.project":           "VertexAI project for Gemini provider",
+	"gemini.location":          "VertexAI location for Gemini provider",
+	"gemini.backend":           "Gemini backend (BackendGeminiAPI or BackendVertexAI)",
+	"gemini.api_key":           "API key for Gemini provider",
 }
 
 // configListCmd represents the command to list the configuration values.
@@ -65,7 +69,7 @@ var configListCmd = &cobra.Command{
 		// Add the key and value to the table
 		for _, v := range keys {
 			// Hide the api key
-			if v == "openai.api_key" {
+			if v == "openai.api_key" || v == "gemini.api_key" {
 				tbl.AddRow(v, "****************")
 				continue
 			}

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -33,6 +33,12 @@ func init() {
 	configSetCmd.Flags().StringP("headers", "", "", availableKeys["openai.headers"])
 	configSetCmd.Flags().StringP("api_version", "", "", availableKeys["openai.api_version"])
 	configSetCmd.Flags().StringP("prompt_folder", "", "", availableKeys["prompt.folder"])
+	// Gemini flags
+	configSetCmd.Flags().String("gemini.project", "", availableKeys["gemini.project"])
+	configSetCmd.Flags().String("gemini.location", "", availableKeys["gemini.location"])
+	configSetCmd.Flags().String("gemini.backend", "BackendGeminiAPI", availableKeys["gemini.backend"])
+	configSetCmd.Flags().String("gemini.api_key", "", availableKeys["gemini.api_key"])
+
 	_ = viper.BindPFlag("openai.base_url", configSetCmd.Flags().Lookup("base_url"))
 	_ = viper.BindPFlag("openai.org_id", configSetCmd.Flags().Lookup("org_id"))
 	_ = viper.BindPFlag("openai.api_key", configSetCmd.Flags().Lookup("api_key"))
@@ -52,6 +58,10 @@ func init() {
 	_ = viper.BindPFlag("openai.headers", configSetCmd.Flags().Lookup("headers"))
 	_ = viper.BindPFlag("openai.api_version", configSetCmd.Flags().Lookup("api_version"))
 	_ = viper.BindPFlag("prompt.folder", configSetCmd.Flags().Lookup("prompt_folder"))
+	_ = viper.BindPFlag("gemini.project", configSetCmd.Flags().Lookup("gemini.project"))
+	_ = viper.BindPFlag("gemini.location", configSetCmd.Flags().Lookup("gemini.location"))
+	_ = viper.BindPFlag("gemini.backend", configSetCmd.Flags().Lookup("gemini.backend"))
+	_ = viper.BindPFlag("gemini.api_key", configSetCmd.Flags().Lookup("gemini.api_key"))
 }
 
 // configSetCmd updates the config value.

--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -35,13 +35,20 @@ func NewOpenAI() (*openai.Client, error) {
 
 // NewGemini returns a new Gemini client
 func NewGemini(ctx context.Context) (*gemini.Client, error) {
+	apiKey := viper.GetString("gemini.api_key")
+	if apiKey == "" {
+		apiKey = viper.GetString("openai.api_key")
+	}
 	return gemini.New(
 		ctx,
-		gemini.WithToken(viper.GetString("openai.api_key")),
+		gemini.WithToken(apiKey),
 		gemini.WithModel(viper.GetString("openai.model")),
 		gemini.WithMaxTokens(viper.GetInt32("openai.max_tokens")),
 		gemini.WithTemperature(float32(viper.GetFloat64("openai.temperature"))),
 		gemini.WithTopP(float32(viper.GetFloat64("openai.top_p"))),
+		gemini.WithBackend(viper.GetString("gemini.backend")),
+		gemini.WithProject(viper.GetString("gemini.project")),
+		gemini.WithLocation(viper.GetString("gemini.location")),
 	)
 }
 

--- a/provider/gemini/gemini.go
+++ b/provider/gemini/gemini.go
@@ -159,11 +159,26 @@ func New(ctx context.Context, opts ...Option) (c *Client, err error) {
 		},
 	}
 
-	client, err := genai.NewClient(ctx, &genai.ClientConfig{
-		APIKey:     cfg.token,
-		HTTPClient: httpClient,
-		Backend:    genai.BackendGeminiAPI,
-	})
+	var clientConfig *genai.ClientConfig
+	switch cfg.backend {
+	case genai.BackendVertexAI:
+		clientConfig = &genai.ClientConfig{
+			HTTPClient: httpClient,
+			Backend:    cfg.backend,
+			Project:    cfg.project,
+			Location:   cfg.location,
+		}
+	case genai.BackendGeminiAPI, genai.BackendUnspecified:
+		fallthrough
+	default:
+		cfg.backend = genai.BackendGeminiAPI
+		clientConfig = &genai.ClientConfig{
+			APIKey:     cfg.token,
+			HTTPClient: httpClient,
+			Backend:    cfg.backend,
+		}
+	}
+	client, err := genai.NewClient(ctx, clientConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Add support for configuring Gemini provider with project, location, backend, and API key options
- Register new Gemini-related flags in the config set command and bind them to viper
- Update Gemini provider initialization to use new config values and allow fallback to OpenAI API key
- Enhance Gemini client creation to support both VertexAI and GeminiAPI backends, including project and location when needed
- Extend Gemini provider options with WithProject, WithLocation, and WithBackend functions
- Improve config validation to require project and location for VertexAI backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new configuration options for the Gemini provider: project, location, backend type, and API key.
  - Introduced command-line flags to set Gemini-specific configuration values.

- **Enhancements**
  - Enabled support for multiple Gemini backend types with dynamic client configuration.
  - Improved validation to require project and location for VertexAI backend or API key for Gemini API backend.

- **Bug Fixes**
  - Prioritized use of Gemini-specific API key with fallback to existing key when unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->