### PR TITLE
refactor: standardize Gemini config to use project_id consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,14 +245,14 @@ Update the following parameters in your config file.
 
 #### Configuration Options
 
-| Option              | Description                                                                                      | Example Value      | Required | Default            |
-| ------------------- | ------------------------------------------------------------------------------------------------ | ------------------ | -------- | ------------------ |
-| **openai.provider** | Set to `gemini` to use Gemini provider                                                           | `gemini`           | Yes      |                    |
-| **gemini.api_key**  | API key for Gemini or VertexAI                                                                   | `xxxxxxx`          | Yes      |                    |
-| **gemini.model**    | Model name (see [Gemini models][61])                                                             | `gemini-2.0-flash` | Yes      |                    |
-| **gemini.backend**  | Gemini backend: `BackendGeminiAPI` (default, for Gemini API) or `BackendVertexAI` (for VertexAI) | `BackendGeminiAPI` | No       | `BackendGeminiAPI` |
-| **gemini.project**  | VertexAI project ID (required if using `BackendVertexAI`)                                        | `my-gcp-project`   | Cond.    |                    |
-| **gemini.location** | VertexAI location (required if using `BackendVertexAI`)                                          | `us-central1`      | Cond.    |                    |
+| Option                | Description                                                                                      | Example Value      | Required | Default            |
+| --------------------- | ------------------------------------------------------------------------------------------------ | ------------------ | -------- | ------------------ |
+| **openai.provider**   | Set to `gemini` to use Gemini provider                                                           | `gemini`           | Yes      |                    |
+| **gemini.api_key**    | API key for Gemini or VertexAI                                                                   | `xxxxxxx`          | Yes      |                    |
+| **gemini.model**      | Model name (see [Gemini models][61])                                                             | `gemini-2.0-flash` | Yes      |                    |
+| **gemini.backend**    | Gemini backend: `BackendGeminiAPI` (default, for Gemini API) or `BackendVertexAI` (for VertexAI) | `BackendGeminiAPI` | No       | `BackendGeminiAPI` |
+| **gemini.project_id** | VertexAI project ID (required if using `BackendVertexAI`)                                        | `my-gcp-project`   | Cond.    |                    |
+| **gemini.location**   | VertexAI location (required if using `BackendVertexAI`)                                          | `us-central1`      | Cond.    |                    |
 
 #### Example: Gemini API (default backend)
 
@@ -269,7 +269,7 @@ codegpt config set gemini.api_key xxxxxxx
 codegpt config set openai.provider gemini
 codegpt config set openai.model gemini-2.0-flash
 codegpt config set gemini.backend BackendVertexAI
-codegpt config set gemini.project my-gcp-project
+codegpt config set gemini.project_id my-gcp-project
 codegpt config set gemini.location us-central1
 ```
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -233,14 +233,14 @@ codegpt config set openai.model xxxxx-gpt-4o
 
 #### 配置选项
 
-| 选项                | 描述                                                                                       | 示例值             | 是否必填 | 默认值             |
-| ------------------- | ------------------------------------------------------------------------------------------ | ------------------ | -------- | ------------------ |
-| **openai.provider** | 设置为 `gemini` 以使用 Gemini 提供商                                                       | `gemini`           | 是       |                    |
-| **gemini.api_key**  | Gemini 或 VertexAI 的 API key                                                              | `xxxxxxx`          | 是       |                    |
-| **gemini.model**    | 模型名称（参见 [Gemini 模型][61]）                                                         | `gemini-2.0-flash` | 是       |                    |
-| **gemini.backend**  | Gemini 后端：`BackendGeminiAPI`（默认，适用于 Gemini API）或 `BackendVertexAI`（VertexAI） | `BackendGeminiAPI` | 否       | `BackendGeminiAPI` |
-| **gemini.project**  | VertexAI 项目 ID（如使用 `BackendVertexAI` 必填）                                          | `my-gcp-project`   | 条件必填 |                    |
-| **gemini.location** | VertexAI 区域（如使用 `BackendVertexAI` 必填）                                             | `us-central1`      | 条件必填 |                    |
+| 选项                  | 描述                                                                                       | 示例值             | 是否必填 | 默认值             |
+| --------------------- | ------------------------------------------------------------------------------------------ | ------------------ | -------- | ------------------ |
+| **openai.provider**   | 设置为 `gemini` 以使用 Gemini 提供商                                                       | `gemini`           | 是       |                    |
+| **gemini.api_key**    | Gemini 或 VertexAI 的 API key                                                              | `xxxxxxx`          | 是       |                    |
+| **gemini.model**      | 模型名称（参见 [Gemini 模型][61]）                                                         | `gemini-2.0-flash` | 是       |                    |
+| **gemini.backend**    | Gemini 后端：`BackendGeminiAPI`（默认，适用于 Gemini API）或 `BackendVertexAI`（VertexAI） | `BackendGeminiAPI` | 否       | `BackendGeminiAPI` |
+| **gemini.project_id** | VertexAI 项目 ID（如使用 `BackendVertexAI` 必填）                                          | `my-gcp-project`   | 条件必填 |                    |
+| **gemini.location**   | VertexAI 区域（如使用 `BackendVertexAI` 必填）                                             | `us-central1`      | 条件必填 |                    |
 
 #### 示例：Gemini API（默认后端）
 
@@ -257,7 +257,7 @@ codegpt config set openai.model gemini-2.0-flash
 codegpt config set openai.provider gemini
 codegpt config set openai.model gemini-1.5-pro-preview-0409
 codegpt config set gemini.backend BackendVertexAI
-codegpt config set gemini.project my-gcp-project
+codegpt config set gemini.project_id my-gcp-project
 codegpt config set gemini.location us-central1
 ```
 

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -244,14 +244,14 @@ codegpt config set openai.model xxxxx-gpt-4o
 
 #### 設定選項
 
-| 選項                | 說明                                                                                       | 範例值             | 必填     | 預設值             |
-| ------------------- | ------------------------------------------------------------------------------------------ | ------------------ | -------- | ------------------ |
-| **openai.provider** | 設為 `gemini` 以使用 Gemini 提供者                                                         | `gemini`           | 是       |                    |
-| **gemini.api_key**  | Gemini 或 VertexAI 的 API 金鑰                                                             | `xxxxxxx`          | 是       |                    |
-| **gemini.model**    | 模型名稱（參見 [Gemini 模型][61]）                                                         | `gemini-2.0-flash` | 是       |                    |
-| **gemini.backend**  | Gemini 後端：`BackendGeminiAPI`（預設，適用於 Gemini API）或 `BackendVertexAI`（VertexAI） | `BackendGeminiAPI` | 否       | `BackendGeminiAPI` |
-| **gemini.project**  | VertexAI 專案 ID（如使用 `BackendVertexAI` 必填）                                          | `my-gcp-project`   | 條件必填 |                    |
-| **gemini.location** | VertexAI 區域（如使用 `BackendVertexAI` 必填）                                             | `us-central1`      | 條件必填 |                    |
+| 選項                  | 說明                                                                                       | 範例值             | 必填     | 預設值             |
+| --------------------- | ------------------------------------------------------------------------------------------ | ------------------ | -------- | ------------------ |
+| **openai.provider**   | 設為 `gemini` 以使用 Gemini 提供者                                                         | `gemini`           | 是       |                    |
+| **gemini.api_key**    | Gemini 或 VertexAI 的 API 金鑰                                                             | `xxxxxxx`          | 是       |                    |
+| **gemini.model**      | 模型名稱（參見 [Gemini 模型][61]）                                                         | `gemini-2.0-flash` | 是       |                    |
+| **gemini.backend**    | Gemini 後端：`BackendGeminiAPI`（預設，適用於 Gemini API）或 `BackendVertexAI`（VertexAI） | `BackendGeminiAPI` | 否       | `BackendGeminiAPI` |
+| **gemini.project_id** | VertexAI 專案 ID（如使用 `BackendVertexAI` 必填）                                          | `my-gcp-project`   | 條件必填 |                    |
+| **gemini.location**   | VertexAI 區域（如使用 `BackendVertexAI` 必填）                                             | `us-central1`      | 條件必填 |                    |
 
 #### 範例：Gemini API（預設後端）
 
@@ -268,7 +268,7 @@ codegpt config set openai.model gemini-2.0-flash
 codegpt config set openai.provider gemini
 codegpt config set openai.model gemini-1.5-pro-preview-0409
 codegpt config set gemini.backend BackendVertexAI
-codegpt config set gemini.project my-gcp-project
+codegpt config set gemini.project_id my-gcp-project
 codegpt config set gemini.location us-central1
 ```
 

--- a/cmd/config_list.go
+++ b/cmd/config_list.go
@@ -37,7 +37,7 @@ var availableKeys = map[string]string{
 	"openai.frequency_penalty": "Parameter to reduce repetition by penalizing tokens based on their frequency",
 	"openai.presence_penalty":  "Parameter to encourage topic diversity by penalizing previously used tokens",
 	"prompt.folder":            "Directory path for custom prompt templates",
-	"gemini.project":           "VertexAI project for Gemini provider",
+	"gemini.project_id":        "VertexAI project for Gemini provider",
 	"gemini.location":          "VertexAI location for Gemini provider",
 	"gemini.backend":           "Gemini backend (BackendGeminiAPI or BackendVertexAI)",
 	"gemini.api_key":           "API key for Gemini provider",

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -34,7 +34,7 @@ func init() {
 	configSetCmd.Flags().StringP("api_version", "", "", availableKeys["openai.api_version"])
 	configSetCmd.Flags().StringP("prompt_folder", "", "", availableKeys["prompt.folder"])
 	// Gemini flags
-	configSetCmd.Flags().String("gemini.project", "", availableKeys["gemini.project"])
+	configSetCmd.Flags().String("gemini.project_id", "", availableKeys["gemini.project_id"])
 	configSetCmd.Flags().String("gemini.location", "", availableKeys["gemini.location"])
 	configSetCmd.Flags().String("gemini.backend", "BackendGeminiAPI", availableKeys["gemini.backend"])
 	configSetCmd.Flags().String("gemini.api_key", "", availableKeys["gemini.api_key"])
@@ -58,7 +58,7 @@ func init() {
 	_ = viper.BindPFlag("openai.headers", configSetCmd.Flags().Lookup("headers"))
 	_ = viper.BindPFlag("openai.api_version", configSetCmd.Flags().Lookup("api_version"))
 	_ = viper.BindPFlag("prompt.folder", configSetCmd.Flags().Lookup("prompt_folder"))
-	_ = viper.BindPFlag("gemini.project", configSetCmd.Flags().Lookup("gemini.project"))
+	_ = viper.BindPFlag("gemini.project_id", configSetCmd.Flags().Lookup("gemini.project_id"))
 	_ = viper.BindPFlag("gemini.location", configSetCmd.Flags().Lookup("gemini.location"))
 	_ = viper.BindPFlag("gemini.backend", configSetCmd.Flags().Lookup("gemini.backend"))
 	_ = viper.BindPFlag("gemini.api_key", configSetCmd.Flags().Lookup("gemini.api_key"))

--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -47,7 +47,7 @@ func NewGemini(ctx context.Context) (*gemini.Client, error) {
 		gemini.WithTemperature(float32(viper.GetFloat64("openai.temperature"))),
 		gemini.WithTopP(float32(viper.GetFloat64("openai.top_p"))),
 		gemini.WithBackend(viper.GetString("gemini.backend")),
-		gemini.WithProject(viper.GetString("gemini.project")),
+		gemini.WithProject(viper.GetString("gemini.project_id")),
 		gemini.WithLocation(viper.GetString("gemini.location")),
 	)
 }

--- a/provider/gemini/gemini.go
+++ b/provider/gemini/gemini.go
@@ -165,7 +165,7 @@ func New(ctx context.Context, opts ...Option) (c *Client, err error) {
 		clientConfig = &genai.ClientConfig{
 			HTTPClient: httpClient,
 			Backend:    cfg.backend,
-			Project:    cfg.project,
+			Project:    cfg.projectID,
 			Location:   cfg.location,
 		}
 	case genai.BackendGeminiAPI, genai.BackendUnspecified:

--- a/provider/gemini/options.go
+++ b/provider/gemini/options.go
@@ -88,14 +88,14 @@ type config struct {
 	maxTokens   int32
 	temperature float32
 	topP        float32
-	project     string
+	projectID   string
 	location    string
 	backend     genai.Backend
 }
 
 func (cfg *config) valid() error {
 	if cfg.backend == genai.BackendVertexAI {
-		if cfg.project == "" || cfg.location == "" {
+		if cfg.projectID == "" || cfg.location == "" {
 			return errorsMissingTokenOrProject
 		}
 	} else {
@@ -132,7 +132,7 @@ func WithBackend(val string) Option {
 
 func WithProject(val string) Option {
 	return optionFunc(func(c *config) {
-		c.project = val
+		c.projectID = val
 	})
 }
 


### PR DESCRIPTION
- Rename the configuration key gemini.project to gemini.project_id throughout documentation and code
- Update all related code, flags, and validation to use projectID instead of project in the Gemini provider configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated all documentation to rename the Gemini API configuration key from `gemini.project` to `gemini.project_id` for clarity and consistency across English, Simplified Chinese, and Traditional Chinese READMEs.
  - Improved table formatting in localized documentation.

- **Refactor**
  - Renamed internal configuration fields and references from `project` to `projectID` for the Gemini provider.
  - Updated command-line flag and configuration key names to match the new naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->