### PR TITLE
fix: enhance PR title generation with retries and better errors

### DIFF
--- a/provider/openai/openai.go
+++ b/provider/openai/openai.go
@@ -180,6 +180,13 @@ func (c *Client) completion(
 	if err != nil {
 		return nil, err
 	}
+	if len(r.Choices) == 0 {
+		return nil, fmt.Errorf("no choices returned from API")
+	}
+	// Do not support reasoning content for now.
+	if r.Choices[0].Message.ReasoningContent != "" {
+		return nil, fmt.Errorf("reasoning model is not supported")
+	}
 	resp.Content = r.Choices[0].Message.Content
 	resp.Usage = r.Usage
 	return resp, nil


### PR DESCRIPTION
- Add retry logic for generating the pull request title, retrying up to 3 times if the response is empty
- Return an explicit error if the OpenAI API returns no choices, or if reasoning content is present (unsupported)
- Improve error reporting for failed title generation attempts
    
fix https://github.com/appleboy/CodeGPT/issues/242


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved pull request title generation with automatic retries for empty results, ensuring more reliable titles.
- **Bug Fixes**
  - Enhanced error handling for AI-generated chat completions, including checks for empty responses and unsupported reasoning content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->