### PR TITLE
feat: enable insecure mode via INSECURE environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,15 +130,18 @@ chmod +x install.sh
 
 #### Configurable Environment Variables
 
-| Variable Name | Default Value      | Description                                                 |
-| ------------- | ------------------ | ----------------------------------------------------------- |
-| VERSION       | latest             | The CodeGPT version to install (defaults to latest release) |
-| INSTALL_DIR   | $HOME/.codegpt/bin | Installation directory                                      |
-| CURL_INSECURE | false              | Skip SSL verification (true/false)                          |
+| Variable Name | Default Value      | Description                                                                   |
+| ------------- | ------------------ | ----------------------------------------------------------------------------- |
+| VERSION       | latest             | The CodeGPT version to install (defaults to latest release)                   |
+| INSTALL_DIR   | $HOME/.codegpt/bin | Installation directory                                                        |
+| INSECURE      | unset (disabled)   | If set to any value, skips SSL verification. Enabled when variable is present |
 
 Example usage:
 
 ```sh
+# Install with insecure mode enabled (ignoring curl SSL verification):
+INSECURE=1 ./install.sh
+
 # Install a specific version to a custom directory:
 VERSION=1.1.0 INSTALL_DIR=/opt/codegpt ./install.sh
 ```

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -127,13 +127,16 @@ chmod +x install.sh
 
 | 变量名        | 默认值             | 说明                                      |
 | ------------- | ------------------ | ----------------------------------------- |
-| VERSION       | latest             | 要安装的 CodeGPT 版本（默认为最新发布版） |
-| INSTALL_DIR   | $HOME/.codegpt/bin | 安装目录                                  |
-| CURL_INSECURE | false              | 是否跳过 SSL 验证 (true/false)            |
+| VERSION       | latest             | 要安装的 CodeGPT 版本（默认为最新发布版）               |
+| INSTALL_DIR   | $HOME/.codegpt/bin | 安装目录                                               |
+| INSECURE      | 未设置（默认关闭）  | 只要设置该变量（值不限），即跳过 SSL 验证               |
 
 使用示例：
 
 ```sh
+# 启用 insecure 模式（跳过 curl SSL 验证）
+INSECURE=1 ./install.sh
+
 # 安装指定版本到自定义目录
 VERSION=1.1.0 INSTALL_DIR=/opt/codegpt ./install.sh
 ```

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -131,13 +131,16 @@ chmod +x install.sh
 
 | 變數名稱      | 預設值             | 說明                                      |
 | ------------- | ------------------ | ----------------------------------------- |
-| VERSION       | latest             | 要安裝的 CodeGPT 版本（預設為最新發布版） |
-| INSTALL_DIR   | $HOME/.codegpt/bin | 安裝目錄                                  |
-| CURL_INSECURE | false              | 是否跳過 SSL 驗證 (true/false)            |
+| VERSION       | latest             | 要安裝的 CodeGPT 版本（預設為最新發布版）            |
+| INSTALL_DIR   | $HOME/.codegpt/bin | 安裝目錄                                            |
+| INSECURE      | 未設定（預設停用）  | 只要設定該變數（值不限），就會啟用跳過 SSL 驗證模式   |
 
 使用範例：
 
 ```sh
+# 啟用 insecure 模式（忽略 SSL 驗證）
+INSECURE=1 ./install.sh
+
 # 安裝特定版本到自訂目錄
 VERSION=1.1.0 INSTALL_DIR=/opt/codegpt ./install.sh
 ```


### PR DESCRIPTION
- Change INSECURE configuration to be enabled by presence of the INSECURE variable, replacing the previous true/false CURL_INSECURE approach
- Update documentation in English and Chinese (Simplified, Traditional) to reflect INSECURE variable usage
- Add usage examples showing how to enable insecure mode via INSECURE=1
- Remove validation checks for CURL_INSECURE value and all references to CURL_INSECURE in the script
- Use INSECURE_ARG for curl invocations to manage SSL verification according to the new logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to replace the `CURL_INSECURE` environment variable with `INSECURE` across all language versions of the README.
  * Clarified that setting `INSECURE` to any value will skip SSL verification during installation.
  * Added example usage for enabling insecure mode.

* **Chores**
  * Simplified environment variable handling in the installation script for skipping SSL verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->