### PR TITLE
refactor: handle `prepare-commit-msg` hook installation errors

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -190,7 +190,9 @@ func (c *Command) InstallHook() error {
 
 	target := path.Join(strings.TrimSpace(string(hookPath)), HookPrepareCommitMessageTemplate)
 	if exists, err := file.IsFile(target); err != nil {
-		return err
+		if !os.IsNotExist(err) {
+			return err
+		}
 	} else if exists {
 		return errors.New("hook file prepare-commit-msg exist")
 	}


### PR DESCRIPTION
- Add specific error handling for `prepare-commit-msg` hook installation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where installing a commit hook could fail if the target hook file didn’t exist. The installer now proceeds to create the hook when the file is missing, while still preventing overwrites of existing hooks and surfacing other errors as before. This improves reliability and reduces setup friction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->