### PR TITLE
fix(openai): enable function calling for DeepSeek models

### DIFF
--- a/provider/openai/openai.go
+++ b/provider/openai/openai.go
@@ -141,8 +141,7 @@ func (c *Client) GetSummaryPrefix(ctx context.Context, content string) (*core.Re
 	var err error
 
 	// For known models that don't support function calls, use regular completion directly
-	if checkOSeriesModels.MatchString(c.model) ||
-		strings.Contains(strings.ToLower(c.model), "deepseek") {
+	if checkOSeriesModels.MatchString(c.model) {
 		resp, err = c.CreateChatCompletion(ctx, content)
 		if err != nil || len(resp.Choices) != 1 {
 			return nil, err


### PR DESCRIPTION
## Summary

- Remove the special-case that forces plain text completion for DeepSeek models in `GetSummaryPrefix`, enabling OpenAI-compatible function calling instead.

## Problem

When using a DeepSeek model, `GetSummaryPrefix` in `provider/openai/openai.go` skips function calling and falls back to `CreateChatCompletion` due to this check:

```go
if checkOSeriesModels.MatchString(c.model) ||
    strings.Contains(strings.ToLower(c.model), "deepseek") {
    resp, err = c.CreateChatCompletion(ctx, content)
```

The `conventional_commit.tmpl` prompt asks the model two questions:
1. What's the best label for the commit?
2. What's the best scope for the commit?

Since function calling is bypassed, the model responds with plain text like:

```
feat
auth
```

This raw text is returned directly as `summarize_prefix` (see `openai.go:167-171` — the `ToolCalls == 0` branch returns `msg.Content` without any post-processing), resulting in `"feat\nauth"` instead of the expected `"feat(auth)"` format.

This causes the final commit message to break across lines:

```
feat
auth: add new authentication module
```

Instead of the correct:

```
feat(auth): add new authentication module
```

## Solution

DeepSeek models now officially support OpenAI-compatible function calling. Removing the `strings.Contains(strings.ToLower(c.model), "deepseek")` condition allows DeepSeek models to use the function calling path, which returns structured `prefix` and `scope` arguments that are properly formatted as `prefix(scope)`.

## Test Plan

- [x] Verify `codegpt commit` with a DeepSeek model produces a commit message with `prefix(scope)` format (e.g., `feat(auth): ...`)
- [x] Verify `codegpt commit` with OpenAI o-series models still falls back to plain text completion as expected
- [x] Verify other providers (Anthropic, Gemini) are unaffected
