### PR TITLE
docs(readme): fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -773,7 +773,7 @@ make test
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=appleboy/codegpt&type=Date)](https://star-history.com/#appleboy/codegpt&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=appleboy/codegpt&type=Date)](https://star-history.dera.page/#appleboy/codegpt&Date)
 
 ## Reference
 

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -772,7 +772,7 @@ make test
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=appleboy/codegpt&type=Date)](https://star-history.com/#appleboy/codegpt&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=appleboy/codegpt&type=Date)](https://star-history.dera.page/#appleboy/codegpt&Date)
 
 ## 參考資料（Reference）
 


### PR DESCRIPTION
The star history chart in the README is currently broken and no longer renders because the upstream data source is restricted by GitHub stargazer API limits.

This change moves the chart and its link to the new star-history.dera.page domain so it works again. The chart and link in both README.md and README.zh-tw.md are updated.